### PR TITLE
Remove Link Icons from Image Links

### DIFF
--- a/EssentialEstablishmentGenerator/Settings/CSS/stylesheet.css
+++ b/EssentialEstablishmentGenerator/Settings/CSS/stylesheet.css
@@ -2323,3 +2323,9 @@ pre code {
 .classTable h5{
     margin-bottom:10px
 }
+
+/*removes link icon from below images */
+a.link-external::after {
+    visibility: hidden;
+    content: "";
+}


### PR DESCRIPTION
This code is to remove the link icons from below image links that are imposed by Twine.