### PR TITLE
Update change log lists to semantic html lists

### DIFF
--- a/EssentialEstablishmentGenerator/Meta/Changelog.twee
+++ b/EssentialEstablishmentGenerator/Meta/Changelog.twee
@@ -1,11 +1,14 @@
 :: Changelog
-<blockquote><<run setup.tippy(".btn")>>
-<h4>v.2.2</h4>-<span class="tip" title="Probably more bug squashing still needed!">Fixed most of the weather bugs</span>
--<span class="tip" title="Probably more bug squashing still needed!">Fixed most of the town slider bugs related to wealth and socioeconomic structure.</span>
--<span class="tip" title="Non-town encounters are still slightly hacked together. Will fix them soon!">Sorted out a weird bug with town encounters</span>
--<span class="tip" title="There was one time when everyone was a polygamist. Weird.">Made a more robust relationships system, including half-breed handling.</span>
--<span class="tip" title="Loosely based on the Kinsey scale. I'm very eager to introduce some more realistic representation.">Implemented sexuality.</span>
--<span class="tip" title="Lots to be done here. Have opted for a relatively blocky system- the middle class didn't *really* exist in medieval times.">Implemented class system, which effects relationships & available occupations.</span>
 
-[[Full changelog|ChangelogFull]]
+<blockquote><<run setup.tippy(".btn")>>
+  <h4>v.2.2</h4>
+  <ul>
+    <li class="tip" title="Probably more bug squashing still needed!">Fixed most of the weather bugs</li>
+    <li class="tip" title="Probably more bug squashing still needed!">Fixed most of the town slider bugs related to wealth and socioeconomic structure.</li>
+    <li class="tip" title="Non-town encounters are still slightly hacked together. Will fix them soon!">Sorted out a weird bug with town encounters</li>
+    <li class="tip" title="There was one time when everyone was a polygamist. Weird.">Made a more robust relationships system, including half-breed handling.</li>
+    <li class="tip" title="Loosely based on the Kinsey scale. I'm very eager to introduce some more realistic representation.">Implemented sexuality.</li>
+    <li class="tip" title="Lots to be done here. Have opted for a relatively blocky system- the middle class didn't *really* exist in medieval times.">Implemented class system, which effects relationships & available occupations.</li>
+  </ul>
+  [[Full changelog|ChangelogFull]]
 </blockquote>

--- a/EssentialEstablishmentGenerator/Meta/Changelog.twee
+++ b/EssentialEstablishmentGenerator/Meta/Changelog.twee
@@ -1,6 +1,8 @@
 :: Changelog
 
-<blockquote><<run setup.tippy(".btn")>>
+<blockquote>
+  <<run setup.tippy(".btn")>>
+
   <h4>v.2.2</h4>
   <ul>
     <li class="tip" title="Probably more bug squashing still needed!">Fixed most of the weather bugs</li>
@@ -10,5 +12,6 @@
     <li class="tip" title="Loosely based on the Kinsey scale. I'm very eager to introduce some more realistic representation.">Implemented sexuality.</li>
     <li class="tip" title="Lots to be done here. Have opted for a relatively blocky system- the middle class didn't *really* exist in medieval times.">Implemented class system, which effects relationships & available occupations.</li>
   </ul>
+
   [[Full changelog|ChangelogFull]]
 </blockquote>

--- a/EssentialEstablishmentGenerator/Meta/ChangelogFull.twee
+++ b/EssentialEstablishmentGenerator/Meta/ChangelogFull.twee
@@ -2,187 +2,187 @@
 
 <h4>v.2.2.1</h4>
 <ul>
-	<li class="tip" title="Thanks for reporting this bug!">Fixed sliders not working.</li>
-	<li class="tip" title="Thanks for reporting this bug!">Fixed market vendors resetting each visit.</li>
+  <li class="tip" title="Thanks for reporting this bug!">Fixed sliders not working.</li>
+  <li class="tip" title="Thanks for reporting this bug!">Fixed market vendors resetting each visit.</li>
 </ul>
 
 <h4>v.2.1</h4>
 <ul>
-	<li class="tip" title="Thanks to /u/WishingOnAWendy for this!">Removed the annoying hyperlink symbol for the Patreon & Ko-Fi links</li>
-	<li class="tip" title="Will be expanded upon in future!">Added town squares.</li>
-	<li class="tip" title="Now with extra fishy smell!">Added docks.</li>
-	<li class="tip" title="Over a hundred whacky events.">Added town plot hooks.</li>
-	<li class="tip" title="Also over a hundred whacky events!">Added poster-based plothooks.</li>
-	<li class="tip" title="Hopefully.">Fixed weather playing up, and added an option to omit weather.</li>
-	<li class="tip" title="This will mean that it becomes a lot easier for contributors to write their own code.">Huge behind the scenes overhaul of how things are linked to, simplifying a lot of things.</li>
-	<li class="tip" title="This is still very much in its infancy, and will be expanded upon later.">Created a relationship chart! Now, when people talk of their friend that they met while travelling, you can *meet* that friend!</li>
-	<li class="tip" title="Hopefully.">Bug fixes for town leadership.</li>
-	<li class="tip" title="This will be expanded upon to make more convincing sounding titles.">Blacksmiths that reference sisters or sons etc will now actually have those sisters or sons.</li>
-	<li class="tip" title="Oops.">Properly clamped establishments so they won't have rolls out of bounds.</li>
-	<li class="tip" title="Although I'm quite sure that it would be entertaining to roleplay, I don't think we need a whole town's worth of them.">Fixed editing NPCs defaulting to male acolyte barbarians.</li>
+  <li class="tip" title="Thanks to /u/WishingOnAWendy for this!">Removed the annoying hyperlink symbol for the Patreon & Ko-Fi links</li>
+  <li class="tip" title="Will be expanded upon in future!">Added town squares.</li>
+  <li class="tip" title="Now with extra fishy smell!">Added docks.</li>
+  <li class="tip" title="Over a hundred whacky events.">Added town plot hooks.</li>
+  <li class="tip" title="Also over a hundred whacky events!">Added poster-based plothooks.</li>
+  <li class="tip" title="Hopefully.">Fixed weather playing up, and added an option to omit weather.</li>
+  <li class="tip" title="This will mean that it becomes a lot easier for contributors to write their own code.">Huge behind the scenes overhaul of how things are linked to, simplifying a lot of things.</li>
+  <li class="tip" title="This is still very much in its infancy, and will be expanded upon later.">Created a relationship chart! Now, when people talk of their friend that they met while travelling, you can *meet* that friend!</li>
+  <li class="tip" title="Hopefully.">Bug fixes for town leadership.</li>
+  <li class="tip" title="This will be expanded upon to make more convincing sounding titles.">Blacksmiths that reference sisters or sons etc will now actually have those sisters or sons.</li>
+  <li class="tip" title="Oops.">Properly clamped establishments so they won't have rolls out of bounds.</li>
+  <li class="tip" title="Although I'm quite sure that it would be entertaining to roleplay, I don't think we need a whole town's worth of them.">Fixed editing NPCs defaulting to male acolyte barbarians.</li>
 </ul>
 
 <h4>v.2.0.1</h4>
 <ul>
-	<li class="tip" title="Oops.">Fixed broken town rolls</li>
+  <li class="tip" title="Oops.">Fixed broken town rolls</li>
   <li class="tip" title="Oops.">Uncommented the tavern stuff</li>
-	<li class="tip" title="Also oops.">Fixed NPC relationships not displaying properly</li>
-	<li class="tip" title="Double oops.">Fixed [Object object] bug with town leaders</li>
-	<li class="tip" title="Minor oops.">Fixed toolbox weather</li>
-	<li class="tip" title="Not an oops!">Minor change to the formatting of the start page</li>
+  <li class="tip" title="Also oops.">Fixed NPC relationships not displaying properly</li>
+  <li class="tip" title="Double oops.">Fixed [Object object] bug with town leaders</li>
+  <li class="tip" title="Minor oops.">Fixed toolbox weather</li>
+  <li class="tip" title="Not an oops!">Minor change to the formatting of the start page</li>
 </ul>
 
 <h4>v.2.0</h4>
 <ul>
-	<li class="tip" title="This should make it much more contributor-friendly.">Total rewrite of code.</li>
-	<li class="tip" title="No more renaming the bartender on the fly because he had a weird name that sounded vaguely phallic!">Added support for editing NPCs.</li>
-	<li class="tip" title="I've opted to only generate one of each type of building (even if it's a huge city) to avoid bogging down the user with unnecessary clutter.">Added support for multiple buildings.</li>
-	<li class="tip" title="No more weird menage-a-trois. Not that there's anything wrong with them- I'll implement poly & LGBTQI relationships soon!">Fixed relationships.</li>
-	<li class="tip" title="Woo! Lose your money! Get married! I dunno.">Added tavern carousing.</li>
-	<li class="tip" title="This feeds into the NPC creation process, so the racial makeup of the town makes things more and less likely.">Added racial demographics.</li>
-	<li class="tip" title="This also into the NPC creation process, so professions are no longer a lucky dip.">Improved the profession demographic.</li>
-	<li class="tip" title="Woo! Lose your money! Get married! I dunno.">Added harlots to the brothels.</li>
-	<li class="tip" title="Also added the ability to delete them. Beware, no stability is promised if you delete a building's NPC.">Added list of current NPCs for reference.</li>
-	<li class="tip" title="The meat and potatoes of this came from many of /u/OrkishBlade's wonderful tables over at /r/behindTheTables. Thanks!">Added a scenario generator, complete with NPCs and descriptive text.</li>
-	<li class="tip" title="Thunderbolts and lightning, very very frightening!">Added weather generation.</li>
-	<li class="tip" title="Instead of just 'the sea captain', it's now a genuine NPC like others.">Added depth to tavern patrons.</li>
+  <li class="tip" title="This should make it much more contributor-friendly.">Total rewrite of code.</li>
+  <li class="tip" title="No more renaming the bartender on the fly because he had a weird name that sounded vaguely phallic!">Added support for editing NPCs.</li>
+  <li class="tip" title="I've opted to only generate one of each type of building (even if it's a huge city) to avoid bogging down the user with unnecessary clutter.">Added support for multiple buildings.</li>
+  <li class="tip" title="No more weird menage-a-trois. Not that there's anything wrong with them- I'll implement poly & LGBTQI relationships soon!">Fixed relationships.</li>
+  <li class="tip" title="Woo! Lose your money! Get married! I dunno.">Added tavern carousing.</li>
+  <li class="tip" title="This feeds into the NPC creation process, so the racial makeup of the town makes things more and less likely.">Added racial demographics.</li>
+  <li class="tip" title="This also into the NPC creation process, so professions are no longer a lucky dip.">Improved the profession demographic.</li>
+  <li class="tip" title="Woo! Lose your money! Get married! I dunno.">Added harlots to the brothels.</li>
+  <li class="tip" title="Also added the ability to delete them. Beware, no stability is promised if you delete a building's NPC.">Added list of current NPCs for reference.</li>
+  <li class="tip" title="The meat and potatoes of this came from many of /u/OrkishBlade's wonderful tables over at /r/behindTheTables. Thanks!">Added a scenario generator, complete with NPCs and descriptive text.</li>
+  <li class="tip" title="Thunderbolts and lightning, very very frightening!">Added weather generation.</li>
+  <li class="tip" title="Instead of just 'the sea captain', it's now a genuine NPC like others.">Added depth to tavern patrons.</li>
 </ul>
 
 <h4>v.1.4</h4>
 <ul>
-	<li class="tip" title="Ooooh! Neat!">Added popups!</li>
-	<li class="tip" title="Will be expanded with faction sidequests soon!">Added factions</li>
-	<li class="tip" title="Will add relationships and families at some point">Added NPC history</li>
-	<li class="tip" title="...I hope">Fixed tavern/brothel combos being kinda wacky</li>
-	<li class="tip" title="Will eventually be expanded into being able to visit each person (but not yet!)">Fixed town population to be reliable</li>
-	<li class="tip" title="1 Gold = 100 Silver = 10000 Copper. Great for gritty, grimdark campaigns!">Added support for the popular homebrew rule, the [[Silver Standard|https://redd.it/80f6kt]]</li>
-	<li class="tip" title="Surprise, surprise, a kleptocracy has what could be considered a 'pro crime' policy.">Kleptocracies and magocracies now have special opinions about crime and magic.</li>
-	<li class="tip" title="Even includes BMI!">Changed the way height, weight, and age are calculated to make it more realistically distributed.</li>
-	<li class="tip" title="Fun fact: Scott was responsible for adding fountains to Nethack!">Added linguistic drift for town names for added realism. Huge thanks to [[Dragons Abound|https://heredragonsabound.blogspot.com/]] for the RegEx magic.</li>
+  <li class="tip" title="Ooooh! Neat!">Added popups!</li>
+  <li class="tip" title="Will be expanded with faction sidequests soon!">Added factions</li>
+  <li class="tip" title="Will add relationships and families at some point">Added NPC history</li>
+  <li class="tip" title="...I hope">Fixed tavern/brothel combos being kinda wacky</li>
+  <li class="tip" title="Will eventually be expanded into being able to visit each person (but not yet!)">Fixed town population to be reliable</li>
+  <li class="tip" title="1 Gold = 100 Silver = 10000 Copper. Great for gritty, grimdark campaigns!">Added support for the popular homebrew rule, the [[Silver Standard|https://redd.it/80f6kt]]</li>
+  <li class="tip" title="Surprise, surprise, a kleptocracy has what could be considered a 'pro crime' policy.">Kleptocracies and magocracies now have special opinions about crime and magic.</li>
+  <li class="tip" title="Even includes BMI!">Changed the way height, weight, and age are calculated to make it more realistically distributed.</li>
+  <li class="tip" title="Fun fact: Scott was responsible for adding fountains to Nethack!">Added linguistic drift for town names for added realism. Huge thanks to [[Dragons Abound|https://heredragonsabound.blogspot.com/]] for the RegEx magic.</li>
 </ul>
 
 <h4>v.1.3.5</h4>
 <ul>
-	<li>Added racial last names (at long last! No more dragonborns with the last name "Johnston"!)</li>
-	<li>Added pub rumours, rogue missions, nightmares, raiders, and weather generation to the [[Toolbox]].</li>
-	<li>Added the one-shot murder mystery [[The Poisoned Potioner|AdventureOutput]]; a self-contained murder to keep your PCs occupied for an hour!</li>
+  <li>Added racial last names (at long last! No more dragonborns with the last name "Johnston"!)</li>
+  <li>Added pub rumours, rogue missions, nightmares, raiders, and weather generation to the [[Toolbox]].</li>
+  <li>Added the one-shot murder mystery [[The Poisoned Potioner|AdventureOutput]]; a self-contained murder to keep your PCs occupied for an hour!</li>
   <li class="tip" title="I'm aware that it is ridiculous that this was not a feature">Added beards</li>
   <li class="tip" title="Parle vous francais?">Added languages</li>
   <li>Changed the way indirect referencing works; instead of solely "the tall man", "the slightly shorter than average woman", or "the dwarf", different attributes are stitched together and put into an array, drawing from the array randomly; NPCs with beards will sometimes be referenced indirectly as "the half elf with a scraggly beard", etc.</li>
-	<li>Added support for future adventure modules. I am trying to keep things so there's no way you can write yourself into a corner by just reading out what's generated, so all default text is largely cosmetic- there's never going to be "you walk into a tavern, and they decide to rob you for all you're worth". This means that adventure modules will only run if loaded, so you'll never have witches turning the players into ducks if you're just looking for an application to spit out a description of a tavern.</li>
-	<li>Behind the scenes work on adding temples, wizard councils, and thieve's guilds, complete with missions (the rogue missions being an example of the sort of stuff that will be generated)!</li>
-	<li class="tip" title="Give me money please">Added a Patreon button to the sidebar</li>
-	<li>Couple of loose ends</li>
-	<li>Minor code cleanup</li>
+  <li>Added support for future adventure modules. I am trying to keep things so there's no way you can write yourself into a corner by just reading out what's generated, so all default text is largely cosmetic- there's never going to be "you walk into a tavern, and they decide to rob you for all you're worth". This means that adventure modules will only run if loaded, so you'll never have witches turning the players into ducks if you're just looking for an application to spit out a description of a tavern.</li>
+  <li>Behind the scenes work on adding temples, wizard councils, and thieve's guilds, complete with missions (the rogue missions being an example of the sort of stuff that will be generated)!</li>
+  <li class="tip" title="Give me money please">Added a Patreon button to the sidebar</li>
+  <li>Couple of loose ends</li>
+  <li>Minor code cleanup</li>
 </ul>
 
 <h4>v.1.3.2</h4>
 <ul>
-	<li class="tip" title="I explain this peculiar bug in a Patreon post!">Fixed an issue where a pimp was being created every single passage change, resulting in LOTS of pimps, and TERRIBLE performance. Things should hopefully be a bit snappier, now that there's not a linearly growing pimp population...</li>
+  <li class="tip" title="I explain this peculiar bug in a Patreon post!">Fixed an issue where a pimp was being created every single passage change, resulting in LOTS of pimps, and TERRIBLE performance. Things should hopefully be a bit snappier, now that there's not a linearly growing pimp population...</li>
 </ul>
 
 <h4>v.1.3.1</h4>
 <ul>
-	<li>I realised that I accidentally left in the half-baked code for population occupations, which doesn't quite work for small towns, but I've left it in anyways. It's in town descriptions.</li>
-	<li>Added Patreon Content slider reintroducing Jasher Drake's halfling warlock!</li>
-	<li>Minor text fixes</li>
+  <li>I realised that I accidentally left in the half-baked code for population occupations, which doesn't quite work for small towns, but I've left it in anyways. It's in town descriptions.</li>
+  <li>Added Patreon Content slider reintroducing Jasher Drake's halfling warlock!</li>
+  <li>Minor text fixes</li>
 </ul>
 
 <h4>v.1.3</h4>
 <ul>
-	<li>Added tutorial</li>
-	<li>Added popups to remind people of the settings page</li>
-	<li>Added guards</li>
-	<li>Added tavern brawls</li>
-	<li>Shifted town descriptions into its own page</li>
-	<li>Added <<linkreplace "town political sources">>republics, constitutional monarchies, absolute monarchies, and anarchist political ideological sources<</linkreplace>></li>
-	<li>Added <<linkreplace "town political ideologies">>autocratic, meritocratic, democratic, kleptocratic, magocratic, militocratic, oligarchic, pedocratic, theocratic, technocratic ideologies<</linkreplace>></li>
-	<li>Added <<linkreplace "town economic policies">>feudalist, capitalist, syndicalist, communist, and primitivist economic policies<</linkreplace>></li>
-	<li>Added town free trade, welfare, magic control, military, and punishment sliders.</li>
-	<li>Added what the town grew around, and their crops, and exports.</li>
+  <li>Added tutorial</li>
+  <li>Added popups to remind people of the settings page</li>
+  <li>Added guards</li>
+  <li>Added tavern brawls</li>
+  <li>Shifted town descriptions into its own page</li>
+  <li>Added <<linkreplace "town political sources">>republics, constitutional monarchies, absolute monarchies, and anarchist political ideological sources<</linkreplace>></li>
+  <li>Added <<linkreplace "town political ideologies">>autocratic, meritocratic, democratic, kleptocratic, magocratic, militocratic, oligarchic, pedocratic, theocratic, technocratic ideologies<</linkreplace>></li>
+  <li>Added <<linkreplace "town economic policies">>feudalist, capitalist, syndicalist, communist, and primitivist economic policies<</linkreplace>></li>
+  <li>Added town free trade, welfare, magic control, military, and punishment sliders.</li>
+  <li>Added what the town grew around, and their crops, and exports.</li>
 </ul>
 
 <h4>v.1.2.2</h4>
 <ul>
-	<li>Minor additions.</li>
-	<li>Redid a couple wordings</li>
-	<li>Added vocal patterns</li>
-	<li>Added vegetation (more detail will be added in future!)</li>
-	<li>Added more to NPC Profile Pages</li>
+  <li>Minor additions.</li>
+  <li>Redid a couple wordings</li>
+  <li>Added vocal patterns</li>
+  <li>Added vegetation (more detail will be added in future!)</li>
+  <li>Added more to NPC Profile Pages</li>
 </ul>
 
 <h4>v.1.2.1</h4>
 <ul>
-	<li>Added link to randomize town landmark.</li>
-	<li>Added link to refresh town.</li>
-	<li>Fixed broken sidebar link to suggestions.</li>
+  <li>Added link to randomize town landmark.</li>
+  <li>Added link to refresh town.</li>
+  <li>Fixed broken sidebar link to suggestions.</li>
 </ul>
 
 <h4>v.1.2</h4>
 <ul>
-	<li>Added the Patreon supporter Jasher Drake's halfling warlock <<linkappend "Tylien Birchbottom">>; captured by cultists as a young lad, he was almost sacrificed to 'The Beast of Shadows', but was rescued at the last minute. After his ordeal, Tylien found himself speaking in tongues and forgetting things. As his memory decayed, he discovered magical powers that he never had before... He now seeks to uncover the mystery of what happened, and what the beast that was summoned is. You might encounter him behind $tavern.name's bar!<</linkappend>></li>
-	<li>Added 'Profile pages' for each NPC for roleplay.</li>
-	<li>Added an option in the sidebar called 'Toolkit'- a collection of random generators.</li>
-	<li>Added a random adventure generator (found in the toolbox)</li>
-	<li>Added town landmarks.</li>
-	<li>Added town current events.</li>
-	<li>Minor CSS changes to try and make things a little bit more bearable while I learn how to do CSS properly...</li>
-	<li>Added the ability to skip the sliders stage</li>
+  <li>Added the Patreon supporter Jasher Drake's halfling warlock <<linkappend "Tylien Birchbottom">>; captured by cultists as a young lad, he was almost sacrificed to 'The Beast of Shadows', but was rescued at the last minute. After his ordeal, Tylien found himself speaking in tongues and forgetting things. As his memory decayed, he discovered magical powers that he never had before... He now seeks to uncover the mystery of what happened, and what the beast that was summoned is. You might encounter him behind $tavern.name's bar!<</linkappend>></li>
+  <li>Added 'Profile pages' for each NPC for roleplay.</li>
+  <li>Added an option in the sidebar called 'Toolkit'- a collection of random generators.</li>
+  <li>Added a random adventure generator (found in the toolbox)</li>
+  <li>Added town landmarks.</li>
+  <li>Added town current events.</li>
+  <li>Minor CSS changes to try and make things a little bit more bearable while I learn how to do CSS properly...</li>
+  <li>Added the ability to skip the sliders stage</li>
 </ul>
 
 <h4>v.1.1.5</h4>
 <ul>
-	<li>Added background origins</li>
-	<li>Minor bug fixes with potions</li>
-	<li>Started work on town descriptors</li>
-	<li>Started work on "Starting Campaign" mode, for DMs starting a new campaign.</li>
+  <li>Added background origins</li>
+  <li>Minor bug fixes with potions</li>
+  <li>Started work on town descriptors</li>
+  <li>Started work on "Starting Campaign" mode, for DMs starting a new campaign.</li>
 </ul>
 
 <h4>v.1.1</h4>
 <ul>
-	<li>Added NPC generator in the Tavern</li>
-	<li>Added plothooks for alchemist</li>
-	<li>Added the excellent Solbera fonts</li>
-	<li>Added JavaScript to force specfic attributes to creating NPCs</li>
-	<li>Added backgrounds relevant to NPC classes, and bonds</li>
-	<li>Added more stuff to be added later on</li>
-	<li>Added brothel</li>
-	<li>Added marketplace</li>
+  <li>Added NPC generator in the Tavern</li>
+  <li>Added plothooks for alchemist</li>
+  <li>Added the excellent Solbera fonts</li>
+  <li>Added JavaScript to force specfic attributes to creating NPCs</li>
+  <li>Added backgrounds relevant to NPC classes, and bonds</li>
+  <li>Added more stuff to be added later on</li>
+  <li>Added brothel</li>
+  <li>Added marketplace</li>
 </ul>
 
 <h4>v.1.0</h4>
 <ul>
-	<li>Added Alchemist</li>
-	<li>Added Blacksmith</li>
-	<li>Added General Store</li>
-	<li>Added significant CSS changes</li>
-	<li>Thousands of lines of code all over the place</li>
-	<li>JavaScript creator for NPCs</li>
-	<li>Huge code cleanup as a result of JS.</li>
+  <li>Added Alchemist</li>
+  <li>Added Blacksmith</li>
+  <li>Added General Store</li>
+  <li>Added significant CSS changes</li>
+  <li>Thousands of lines of code all over the place</li>
+  <li>JavaScript creator for NPCs</li>
+  <li>Huge code cleanup as a result of JS.</li>
 </ul>
 
 <h4>v.0.3</h4>
 <ul>
-	<li>Added ability to rename town & tavern</li>
-	<li>Modified room cost formula to mirror the recommended prices</li>
-	<li>CSS Style update</li>
-	<li>Drop caps!</li>
-	<li>Added exclusions for the brothels' main attractions being near the church...</li>
-	<li>Minor code cleanup behind the scenes</li>
+  <li>Added ability to rename town & tavern</li>
+  <li>Modified room cost formula to mirror the recommended prices</li>
+  <li>CSS Style update</li>
+  <li>Drop caps!</li>
+  <li>Added exclusions for the brothels' main attractions being near the church...</li>
+  <li>Minor code cleanup behind the scenes</li>
 </ul>
 
 <h4>v.0.2</h4>
 <ul>
-	<li>Added vegetarian & carnivorous menus based on tavern's roughness.</li>
-	<li>Replaced attribute buttons with sliders (that actually work)</li>
-	<li class="tip" title="Bartender's race will impact the tavern's roughness, cleanliness, etc.">Added races</li>
-	<li class="tip" title="Stolen from the /r/DnDBehindTheScreen 10000 Drinks thread">Added special brews</li>
-	<li class="tip" title="These are kinda hamfisted in, but it's just in case your PCs are really into talking with the bartender, and you need to make up more stuff to keep them interested.">Added bonds</li>
-	<li>Added descriptions of taverns based on size and draw.</li>
-	<li>Made room availability dependent on size, and current population of the tavern.</li>
+  <li>Added vegetarian & carnivorous menus based on tavern's roughness.</li>
+  <li>Replaced attribute buttons with sliders (that actually work)</li>
+  <li class="tip" title="Bartender's race will impact the tavern's roughness, cleanliness, etc.">Added races</li>
+  <li class="tip" title="Stolen from the /r/DnDBehindTheScreen 10000 Drinks thread">Added special brews</li>
+  <li class="tip" title="These are kinda hamfisted in, but it's just in case your PCs are really into talking with the bartender, and you need to make up more stuff to keep them interested.">Added bonds</li>
+  <li>Added descriptions of taverns based on size and draw.</li>
+  <li>Made room availability dependent on size, and current population of the tavern.</li>
 </ul>
 
 <h4>v.0.1</h4>
 <ul>
-	<li class="tip" title="Babby's first steps!">First release</li>
+  <li class="tip" title="Babby's first steps!">First release</li>
 </ul>

--- a/EssentialEstablishmentGenerator/Meta/ChangelogFull.twee
+++ b/EssentialEstablishmentGenerator/Meta/ChangelogFull.twee
@@ -1,132 +1,191 @@
 :: ChangelogFull
-<h4>v.2.2.1</h4>-<span class="tip" title="Thanks for reporting this bug!">Fixed sliders not working.</span>
--<span class="tip" title="Thanks for reporting this bug!">Fixed market vendors resetting each visit.</span>
-<h4>v.2.1</h4>-<span class="tip" title="Thanks to /u/WishingOnAWendy for this!">Removed the annoying hyperlink symbol for the Patreon & Ko-Fi links</span>
--<span class="tip" title="Will be expanded upon in future!">Added town squares.</span>
--<span class="tip" title="Now with extra fishy smell!">Added docks.</span>
--<span class="tip" title="Over a hundred whacky events.">Added town plot hooks.</span>
--<span class="tip" title="Also over a hundred whacky events!">Added poster-based plothooks.</span>
--<span class="tip" title="Hopefully.">Fixed weather playing up, and added an option to omit weather.</span>
--<span class="tip" title="This will mean that it becomes a lot easier for contributors to write their own code.">Huge behind the scenes overhaul of how things are linked to, simplifying a lot of things.</span>
--<span class="tip" title="This is still very much in its infancy, and will be expanded upon later.">Created a relationship chart! Now, when people talk of their friend that they met while travelling, you can *meet* that friend!</span>
--<span class="tip" title="Hopefully.">Bug fixes for town leadership.</span>
--<span class="tip" title="This will be expanded upon to make more convincing sounding titles.">Blacksmiths that reference sisters or sons etc will now actually have those sisters or sons.</span>
--<span class="tip" title="Oops.">Properly clamped establishments so they won't have rolls out of bounds.</span>
--<span class="tip" title="Although I'm quite sure that it would be entertaining to roleplay, I don't think we need a whole town's worth of them.">Fixed editing NPCs defaulting to male acolyte barbarians.</span>
-<h4>v.2.0.1</h4>-<span class="tip" title="Oops.">Fixed broken town rolls</span>
-- <span class="tip" title="Oops.">Uncommented the tavern stuff</span>
-<span class="tip" title="Also oops.">Fixed NPC relationships not displaying properly</span>
-<span class="tip" title="Double oops.">Fixed [Object object] bug with town leaders</span>
-<span class="tip" title="Minor oops.">Fixed toolbox weather</span>
-<span class="tip" title="Not an oops!">Minor change to the formatting of the start page</span>
-<h4>v.2.0</h4>- <span class="tip" title="This should make it much more contributor-friendly.">Total rewrite of code.</span>
-- <span class="tip" title="No more renaming the bartender on the fly because he had a weird name that sounded vaguely phallic!">Added support for editing NPCs.</span>
-- <span class="tip" title="I've opted to only generate one of each type of building (even if it's a huge city) to avoid bogging down the user with unnecessary clutter.">Added support for multiple buildings.</span>
-- <span class="tip" title="No more weird menage-a-trois. Not that there's anything wrong with them- I'll implement poly & LGBTQI relationships soon!">Fixed relationships.</span>
-- <span class="tip" title="Woo! Lose your money! Get married! I dunno.">Added tavern carousing.</span>
-- <span class="tip" title="This feeds into the NPC creation process, so the racial makeup of the town makes things more and less likely.">Added racial demographics.</span>
-- <span class="tip" title="This also into the NPC creation process, so professions are no longer a lucky dip.">Improved the profession demographic.</span>
-- <span class="tip" title="Woo! Lose your money! Get married! I dunno.">Added harlots to the brothels.</span>
-- <span class="tip" title="Also added the ability to delete them. Beware, no stability is promised if you delete a building's NPC.">Added list of current NPCs for reference.</span>
-- <span class="tip" title="The meat and potatoes of this came from many of /u/OrkishBlade's wonderful tables over at /r/behindTheTables. Thanks!">Added a scenario generator, complete with NPCs and descriptive text.</span>
-- <span class="tip" title="Thunderbolts and lightning, very very frightening!">Added weather generation.</span>
-- <span class="tip" title="Instead of just 'the sea captain', it's now a genuine NPC like others.">Added depth to tavern patrons.</span>
-<h4>v.1.4</h4>- <span class="tip" title="Ooooh! Neat!">Added popups!</span>
-- <span class="tip" title="Will be expanded with faction sidequests soon!">Added factions</span>
-- <span class="tip" title="Will add relationships and families at some point">Added NPC history</span>
-- <span class="tip" title="...I hope">Fixed tavern/brothel combos being kinda wacky</span>
-- <span class="tip" title="Will eventually be expanded into being able to visit each person (but not yet!)">Fixed town population to be reliable</span>
-- <span class="tip" title="1 Gold = 100 Silver = 10000 Copper. Great for gritty, grimdark campaigns!">Added support for the popular homebrew rule, the [[Silver Standard|https://redd.it/80f6kt]]</span>
-- <span class="tip" title="Surprise, surprise, a kleptocracy has what could be considered a 'pro crime' policy.">Kleptocracies and magocracies now have special opinions about crime and magic.</span>
-- <span class="tip" title="Even includes BMI!">Changed the way height, weight, and age are calculated to make it more realistically distributed.</span>
-- <span class="tip" title="Fun fact: Scott was responsible for adding fountains to Nethack!">Added linguistic drift for town names for added realism. Huge thanks to [[Dragons Abound|https://heredragonsabound.blogspot.com/]] for the RegEx magic.</span>
-<h4>v.1.3.5</h4> - Added racial last names (at long last! No more dragonborns with the last name "Johnston"!)
-- Added pub rumours, rogue missions, nightmares, raiders, and weather generation to the [[Toolbox]].
-- Added the one-shot murder mystery [[The Poisoned Potioner|AdventureOutput]]; a self-contained murder to keep your PCs occupied for an hour!
-- <span class="tip" title="I'm aware that it is ridiculous that this was not a feature">Added beards</span>
-- <span class="tip" title="Parle vous francais?">Added languages</span>
-- Changed the way indirect referencing works; instead of solely "the tall man", "the slightly shorter than average woman", or "the dwarf", different attributes are stitched together and put into an array, drawing from the array randomly; NPCs with beards will sometimes be referenced indirectly as "the half elf with a scraggly beard", etc.
-- Added support for future adventure modules. I am trying to keep things so there's no way you can write yourself into a corner by just reading out what's generated, so all default text is largely cosmetic- there's never going to be "you walk into a tavern, and they decide to rob you for all you're worth". This means that adventure modules will only run if loaded, so you'll never have witches turning the players into ducks if you're just looking for an application to spit out a description of a tavern.
-- Behind the scenes work on adding temples, wizard councils, and thieve's guilds, complete with missions (the rogue missions being an example of the sort of stuff that will be generated)!
-- <span class="tip" title="Give me money please">Added a Patreon button to the sidebar</span>
-- Couple of loose ends
-- Minor code cleanup
 
-<h4>v.1.3.2</h4> - <span class="tip" title="I explain this peculiar bug in a Patreon post!">Fixed an issue where a pimp was being created every single passage change, resulting in LOTS of pimps, and TERRIBLE performance. Things should hopefully be a bit snappier, now that there's not a linearly growing pimp population...</span>
+<h4>v.2.2.1</h4>
+<ul>
+	<li class="tip" title="Thanks for reporting this bug!">Fixed sliders not working.</li>
+	<li class="tip" title="Thanks for reporting this bug!">Fixed market vendors resetting each visit.</li>
+</ul>
 
-<h4>v.1.3.1</h4> - I realised that I accidentally left in the half-baked code for population occupations, which doesn't quite work for small towns, but I've left it in anyways. It's in town descriptions.
-- Added Patreon Content slider reintroducing Jasher Drake's halfling warlock!
-- Minor text fixes
+<h4>v.2.1</h4>
+<ul>
+	<li class="tip" title="Thanks to /u/WishingOnAWendy for this!">Removed the annoying hyperlink symbol for the Patreon & Ko-Fi links</li>
+	<li class="tip" title="Will be expanded upon in future!">Added town squares.</li>
+	<li class="tip" title="Now with extra fishy smell!">Added docks.</li>
+	<li class="tip" title="Over a hundred whacky events.">Added town plot hooks.</li>
+	<li class="tip" title="Also over a hundred whacky events!">Added poster-based plothooks.</li>
+	<li class="tip" title="Hopefully.">Fixed weather playing up, and added an option to omit weather.</li>
+	<li class="tip" title="This will mean that it becomes a lot easier for contributors to write their own code.">Huge behind the scenes overhaul of how things are linked to, simplifying a lot of things.</li>
+	<li class="tip" title="This is still very much in its infancy, and will be expanded upon later.">Created a relationship chart! Now, when people talk of their friend that they met while travelling, you can *meet* that friend!</li>
+	<li class="tip" title="Hopefully.">Bug fixes for town leadership.</li>
+	<li class="tip" title="This will be expanded upon to make more convincing sounding titles.">Blacksmiths that reference sisters or sons etc will now actually have those sisters or sons.</li>
+	<li class="tip" title="Oops.">Properly clamped establishments so they won't have rolls out of bounds.</li>
+	<li class="tip" title="Although I'm quite sure that it would be entertaining to roleplay, I don't think we need a whole town's worth of them.">Fixed editing NPCs defaulting to male acolyte barbarians.</li>
+</ul>
 
-<h4>v.1.3</h4> - Added tutorial
-- Added popups to remind people of the settings page
-- Added guards
-- Added tavern brawls
-- Shifted town descriptions into its own page
-- Added <<linkreplace "town political sources">>republics, constitutional monarchies, absolute monarchies, and anarchist political ideological sources<</linkreplace>>
-- Added <<linkreplace "town political ideologies">>autocratic, meritocratic, democratic, kleptocratic, magocratic, militocratic, oligarchic, pedocratic, theocratic, technocratic ideologies<</linkreplace>>
-- Added <<linkreplace "town economic policies">>feudalist, capitalist, syndicalist, communist, and primitivist economic policies<</linkreplace>>
-- Added town free trade, welfare, magic control, military, and punishment sliders.
-- Added what the town grew around, and their crops, and exports.
+<h4>v.2.0.1</h4>
+<ul>
+	<li class="tip" title="Oops.">Fixed broken town rolls</li>
+  <li class="tip" title="Oops.">Uncommented the tavern stuff</li>
+	<li class="tip" title="Also oops.">Fixed NPC relationships not displaying properly</li>
+	<li class="tip" title="Double oops.">Fixed [Object object] bug with town leaders</li>
+	<li class="tip" title="Minor oops.">Fixed toolbox weather</li>
+	<li class="tip" title="Not an oops!">Minor change to the formatting of the start page</li>
+</ul>
 
-<h4>v.1.2.2</h4> - Minor additions.
-- Redid a couple wordings
-- Added vocal patterns
-- Added vegetation (more detail will be added in future!)
-- Added more to NPC Profile Pages
+<h4>v.2.0</h4>
+<ul>
+	<li class="tip" title="This should make it much more contributor-friendly.">Total rewrite of code.</li>
+	<li class="tip" title="No more renaming the bartender on the fly because he had a weird name that sounded vaguely phallic!">Added support for editing NPCs.</li>
+	<li class="tip" title="I've opted to only generate one of each type of building (even if it's a huge city) to avoid bogging down the user with unnecessary clutter.">Added support for multiple buildings.</li>
+	<li class="tip" title="No more weird menage-a-trois. Not that there's anything wrong with them- I'll implement poly & LGBTQI relationships soon!">Fixed relationships.</li>
+	<li class="tip" title="Woo! Lose your money! Get married! I dunno.">Added tavern carousing.</li>
+	<li class="tip" title="This feeds into the NPC creation process, so the racial makeup of the town makes things more and less likely.">Added racial demographics.</li>
+	<li class="tip" title="This also into the NPC creation process, so professions are no longer a lucky dip.">Improved the profession demographic.</li>
+	<li class="tip" title="Woo! Lose your money! Get married! I dunno.">Added harlots to the brothels.</li>
+	<li class="tip" title="Also added the ability to delete them. Beware, no stability is promised if you delete a building's NPC.">Added list of current NPCs for reference.</li>
+	<li class="tip" title="The meat and potatoes of this came from many of /u/OrkishBlade's wonderful tables over at /r/behindTheTables. Thanks!">Added a scenario generator, complete with NPCs and descriptive text.</li>
+	<li class="tip" title="Thunderbolts and lightning, very very frightening!">Added weather generation.</li>
+	<li class="tip" title="Instead of just 'the sea captain', it's now a genuine NPC like others.">Added depth to tavern patrons.</li>
+</ul>
 
-<h4>v.1.2.1</h4> - Added link to randomize town landmark.
-- Added link to refresh town.
-- Fixed broken sidebar link to suggestions.
+<h4>v.1.4</h4>
+<ul>
+	<li class="tip" title="Ooooh! Neat!">Added popups!</li>
+	<li class="tip" title="Will be expanded with faction sidequests soon!">Added factions</li>
+	<li class="tip" title="Will add relationships and families at some point">Added NPC history</li>
+	<li class="tip" title="...I hope">Fixed tavern/brothel combos being kinda wacky</li>
+	<li class="tip" title="Will eventually be expanded into being able to visit each person (but not yet!)">Fixed town population to be reliable</li>
+	<li class="tip" title="1 Gold = 100 Silver = 10000 Copper. Great for gritty, grimdark campaigns!">Added support for the popular homebrew rule, the [[Silver Standard|https://redd.it/80f6kt]]</li>
+	<li class="tip" title="Surprise, surprise, a kleptocracy has what could be considered a 'pro crime' policy.">Kleptocracies and magocracies now have special opinions about crime and magic.</li>
+	<li class="tip" title="Even includes BMI!">Changed the way height, weight, and age are calculated to make it more realistically distributed.</li>
+	<li class="tip" title="Fun fact: Scott was responsible for adding fountains to Nethack!">Added linguistic drift for town names for added realism. Huge thanks to [[Dragons Abound|https://heredragonsabound.blogspot.com/]] for the RegEx magic.</li>
+</ul>
 
-<h4>v.1.2</h4> - Added the Patreon supporter Jasher Drake's halfling warlock <<linkappend "Tylien Birchbottom">>; captured by cultists as a young lad, he was almost sacrificed to 'The Beast of Shadows', but was rescued at the last minute. After his ordeal, Tylien found himself speaking in tongues and forgetting things. As his memory decayed, he discovered magical powers that he never had before... He now seeks to uncover the mystery of what happened, and what the beast that was summoned is. You might encounter him behind $tavern.name's bar!<</linkappend>>
-- Added 'Profile pages' for each NPC for roleplay.
-- Added an option in the sidebar called 'Toolkit'- a collection of random generators.
-		- Added a random adventure generator (found in the toolbox)
-- Added town landmarks.
-- Added town current events.
-- Minor CSS changes to try and make things a little bit more bearable while I learn how to do CSS properly...
-- Added the ability to skip the sliders stage
+<h4>v.1.3.5</h4>
+<ul>
+	<li>Added racial last names (at long last! No more dragonborns with the last name "Johnston"!)</li>
+	<li>Added pub rumours, rogue missions, nightmares, raiders, and weather generation to the [[Toolbox]].</li>
+	<li>Added the one-shot murder mystery [[The Poisoned Potioner|AdventureOutput]]; a self-contained murder to keep your PCs occupied for an hour!</li>
+  <li class="tip" title="I'm aware that it is ridiculous that this was not a feature">Added beards</li>
+  <li class="tip" title="Parle vous francais?">Added languages</li>
+  <li>Changed the way indirect referencing works; instead of solely "the tall man", "the slightly shorter than average woman", or "the dwarf", different attributes are stitched together and put into an array, drawing from the array randomly; NPCs with beards will sometimes be referenced indirectly as "the half elf with a scraggly beard", etc.</li>
+	<li>Added support for future adventure modules. I am trying to keep things so there's no way you can write yourself into a corner by just reading out what's generated, so all default text is largely cosmetic- there's never going to be "you walk into a tavern, and they decide to rob you for all you're worth". This means that adventure modules will only run if loaded, so you'll never have witches turning the players into ducks if you're just looking for an application to spit out a description of a tavern.</li>
+	<li>Behind the scenes work on adding temples, wizard councils, and thieve's guilds, complete with missions (the rogue missions being an example of the sort of stuff that will be generated)!</li>
+	<li class="tip" title="Give me money please">Added a Patreon button to the sidebar</li>
+	<li>Couple of loose ends</li>
+	<li>Minor code cleanup</li>
+</ul>
 
-<h4>v.1.1.5</h4> - Added background origins
-- Minor bug fixes with potions
-- Started work on town descriptors
-- Started work on "Starting Campaign" mode, for DMs starting a new campaign.
+<h4>v.1.3.2</h4>
+<ul>
+	<li class="tip" title="I explain this peculiar bug in a Patreon post!">Fixed an issue where a pimp was being created every single passage change, resulting in LOTS of pimps, and TERRIBLE performance. Things should hopefully be a bit snappier, now that there's not a linearly growing pimp population...</li>
+</ul>
 
-<h4>v.1.1</h4> - Added NPC generator in the Tavern
-- Added plothooks for alchemist
-- Added the excellent Solbera fonts
-- Added JavaScript to force specfic attributes to creating NPCs
-- Added backgrounds relevant to NPC classes, and bonds
-- Added more stuff to be added later on
-- Added brothel
-- Added marketplace
+<h4>v.1.3.1</h4>
+<ul>
+	<li>I realised that I accidentally left in the half-baked code for population occupations, which doesn't quite work for small towns, but I've left it in anyways. It's in town descriptions.</li>
+	<li>Added Patreon Content slider reintroducing Jasher Drake's halfling warlock!</li>
+	<li>Minor text fixes</li>
+</ul>
 
-<h4>v.1.0</h4> - Added Alchemist
-- Added Blacksmith
-- Added General Store
-- Added significant CSS changes
-- Thousands of lines of code all over the place
-- JavaScript creator for NPCs
-- Huge code cleanup as a result of JS.
+<h4>v.1.3</h4>
+<ul>
+	<li>Added tutorial</li>
+	<li>Added popups to remind people of the settings page</li>
+	<li>Added guards</li>
+	<li>Added tavern brawls</li>
+	<li>Shifted town descriptions into its own page</li>
+	<li>Added <<linkreplace "town political sources">>republics, constitutional monarchies, absolute monarchies, and anarchist political ideological sources<</linkreplace>></li>
+	<li>Added <<linkreplace "town political ideologies">>autocratic, meritocratic, democratic, kleptocratic, magocratic, militocratic, oligarchic, pedocratic, theocratic, technocratic ideologies<</linkreplace>></li>
+	<li>Added <<linkreplace "town economic policies">>feudalist, capitalist, syndicalist, communist, and primitivist economic policies<</linkreplace>></li>
+	<li>Added town free trade, welfare, magic control, military, and punishment sliders.</li>
+	<li>Added what the town grew around, and their crops, and exports.</li>
+</ul>
 
+<h4>v.1.2.2</h4>
+<ul>
+	<li>Minor additions.</li>
+	<li>Redid a couple wordings</li>
+	<li>Added vocal patterns</li>
+	<li>Added vegetation (more detail will be added in future!)</li>
+	<li>Added more to NPC Profile Pages</li>
+</ul>
 
-<h4>v.0.3</h4> - Added ability to rename town & tavern
-- Modified room cost formula to mirror the recommended prices
-- CSS Style update
-- Drop caps!
-- Added exclusions for the brothels' main attractions being near the church...
-- Minor code cleanup behind the scenes
+<h4>v.1.2.1</h4>
+<ul>
+	<li>Added link to randomize town landmark.</li>
+	<li>Added link to refresh town.</li>
+	<li>Fixed broken sidebar link to suggestions.</li>
+</ul>
 
-<h4>v.0.2</h4> - Added vegetarian & carnivorous menus based on tavern's roughness.
-- Replaced attribute buttons with sliders (that actually work)
-- Added races
-	<i>Bartender's race will impact the tavern's roughness, cleanliness, etc.</i>
-- Added special brews
-	<i>Stolen from the /r/DnDBehindTheScreen 10000 Drinks thread</i>
-- Added bonds
-	<i>These are kinda hamfisted in, but it's just in case your PCs are really into talking with the bartender, and you need to make up more stuff to keep them interested.</i>
-- Added descriptions of taverns based on size and draw.
-- Made room availability dependent on size, and current population of the tavern.
+<h4>v.1.2</h4>
+<ul>
+	<li>Added the Patreon supporter Jasher Drake's halfling warlock <<linkappend "Tylien Birchbottom">>; captured by cultists as a young lad, he was almost sacrificed to 'The Beast of Shadows', but was rescued at the last minute. After his ordeal, Tylien found himself speaking in tongues and forgetting things. As his memory decayed, he discovered magical powers that he never had before... He now seeks to uncover the mystery of what happened, and what the beast that was summoned is. You might encounter him behind $tavern.name's bar!<</linkappend>></li>
+	<li>Added 'Profile pages' for each NPC for roleplay.</li>
+	<li>Added an option in the sidebar called 'Toolkit'- a collection of random generators.</li>
+	<li>Added a random adventure generator (found in the toolbox)</li>
+	<li>Added town landmarks.</li>
+	<li>Added town current events.</li>
+	<li>Minor CSS changes to try and make things a little bit more bearable while I learn how to do CSS properly...</li>
+	<li>Added the ability to skip the sliders stage</li>
+</ul>
 
-<h4>v.0.1</h4> - <span class="tip" title="Babby's first steps!">First release</span>
+<h4>v.1.1.5</h4>
+<ul>
+	<li>Added background origins</li>
+	<li>Minor bug fixes with potions</li>
+	<li>Started work on town descriptors</li>
+	<li>Started work on "Starting Campaign" mode, for DMs starting a new campaign.</li>
+</ul>
+
+<h4>v.1.1</h4>
+<ul>
+	<li>Added NPC generator in the Tavern</li>
+	<li>Added plothooks for alchemist</li>
+	<li>Added the excellent Solbera fonts</li>
+	<li>Added JavaScript to force specfic attributes to creating NPCs</li>
+	<li>Added backgrounds relevant to NPC classes, and bonds</li>
+	<li>Added more stuff to be added later on</li>
+	<li>Added brothel</li>
+	<li>Added marketplace</li>
+</ul>
+
+<h4>v.1.0</h4>
+<ul>
+	<li>Added Alchemist</li>
+	<li>Added Blacksmith</li>
+	<li>Added General Store</li>
+	<li>Added significant CSS changes</li>
+	<li>Thousands of lines of code all over the place</li>
+	<li>JavaScript creator for NPCs</li>
+	<li>Huge code cleanup as a result of JS.</li>
+</ul>
+
+<h4>v.0.3</h4>
+<ul>
+	<li>Added ability to rename town & tavern</li>
+	<li>Modified room cost formula to mirror the recommended prices</li>
+	<li>CSS Style update</li>
+	<li>Drop caps!</li>
+	<li>Added exclusions for the brothels' main attractions being near the church...</li>
+	<li>Minor code cleanup behind the scenes</li>
+</ul>
+
+<h4>v.0.2</h4>
+<ul>
+	<li>Added vegetarian & carnivorous menus based on tavern's roughness.</li>
+	<li>Replaced attribute buttons with sliders (that actually work)</li>
+	<li>Added racess
+	<i>Bartender's race will impact the tavern's roughness, cleanliness, etc.</i></li>
+	<li>Added special brews
+	<i>Stolen from the /r/DnDBehindTheScreen 10000 Drinks thread</i></li>
+	<li>Added bonds
+	<i>These are kinda hamfisted in, but it's just in case your PCs are really into talking with the bartender, and you need to make up more stuff to keep them interested.</i></li>
+	<li>Added descriptions of taverns based on size and draw.</li>
+	<li>Made room availability dependent on size, and current population of the tavern.</li>
+</ul>
+
+<h4>v.0.1</h4>
+<ul>
+	<li class="tip" title="Babby's first steps!">First release</li>
+</ul>

--- a/EssentialEstablishmentGenerator/Meta/ChangelogFull.twee
+++ b/EssentialEstablishmentGenerator/Meta/ChangelogFull.twee
@@ -175,12 +175,9 @@
 <ul>
 	<li>Added vegetarian & carnivorous menus based on tavern's roughness.</li>
 	<li>Replaced attribute buttons with sliders (that actually work)</li>
-	<li>Added racess
-	<i>Bartender's race will impact the tavern's roughness, cleanliness, etc.</i></li>
-	<li>Added special brews
-	<i>Stolen from the /r/DnDBehindTheScreen 10000 Drinks thread</i></li>
-	<li>Added bonds
-	<i>These are kinda hamfisted in, but it's just in case your PCs are really into talking with the bartender, and you need to make up more stuff to keep them interested.</i></li>
+	<li class="tip" title="Bartender's race will impact the tavern's roughness, cleanliness, etc.">Added races</li>
+	<li class="tip" title="Stolen from the /r/DnDBehindTheScreen 10000 Drinks thread">Added special brews</li>
+	<li class="tip" title="These are kinda hamfisted in, but it's just in case your PCs are really into talking with the bartender, and you need to make up more stuff to keep them interested.">Added bonds</li>
 	<li>Added descriptions of taverns based on size and draw.</li>
 	<li>Made room availability dependent on size, and current population of the tavern.</li>
 </ul>


### PR DESCRIPTION
This aims to update the change log lists from basic dash-prefixed span elements, to semantically correct [html lists](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul).

I have not compiled and verified that this is all working out of the box, so it would be great if somebody could verify that it does.