### PR TITLE
Use twine list syntax for Patreon supporter list

### DIFF
--- a/EssentialEstablishmentGenerator/Meta/PatreonSupporters.twee
+++ b/EssentialEstablishmentGenerator/Meta/PatreonSupporters.twee
@@ -1,14 +1,14 @@
 :: PatreonSupporters
 Special thanks to my [[Patreon|https://www.patreon.com/bePatron?c=1709078]] supporters!
-- Gunnar A Smits
-- Kroy Mortlach
-- Noah David
-- Conrad
-- Lachlan Scott
-- Gordon Randall
-- Thijs Miedema
-- Lewis Kelly
-- Duncan Thomson
-- Wendy Birb
-- Lane Watson
-- Connor Fitzgerald
+* Gunnar A Smits
+* Kroy Mortlach
+* Noah David
+* Conrad
+* Lachlan Scott
+* Gordon Randall
+* Thijs Miedema
+* Lewis Kelly
+* Duncan Thomson
+* Wendy Birb
+* Lane Watson
+* Connor Fitzgerald


### PR DESCRIPTION
[Apparently](http://twinery.org/wiki/syntax), the official way to make an unordered list in Twine is to use `*` syntax.

This is converted into `ul` and `li` tags upon compilation.

This PR applies this to the Patreon supporter list.