### PR TITLE
Fix line breaks in changelog

### DIFF
--- a/EssentialEstablishmentGenerator/Meta/Changelog.twee
+++ b/EssentialEstablishmentGenerator/Meta/Changelog.twee
@@ -1,5 +1,6 @@
 :: Changelog
 
+<<nobr>>
 <blockquote>
   <<run setup.tippy(".btn")>>
 
@@ -15,3 +16,4 @@
 
   [[Full changelog|ChangelogFull]]
 </blockquote>
+<<endnobr>>

--- a/EssentialEstablishmentGenerator/Meta/ChangelogFull.twee
+++ b/EssentialEstablishmentGenerator/Meta/ChangelogFull.twee
@@ -1,4 +1,5 @@
 :: ChangelogFull
+<<nobr>>
 
 <h4>v.2.2.1</h4>
 <ul>
@@ -186,3 +187,5 @@
 <ul>
   <li class="tip" title="Babby's first steps!">First release</li>
 </ul>
+
+<<endnobr>>


### PR DESCRIPTION
Removes the extra line breaks introduced when formatting the changelogs.