### PR TITLE
Add automatic tweego downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 
 **What It's For**
+
 * Generate thousands of unique towns for table play
 * Create new plothooks for games
 * Generate new NPCs to flesh out existing places
@@ -19,7 +20,9 @@ Go to https://eigengrausgenerator.com/ to see the most current live build of EEE
 NOTE: The live build is often several weeks or months behind the current build here on GitHub. Compile the generator locally to see all the latest features and updates!
 
 ## Community :family:
+
 **Join our Discord to talk about the project in real time**
+
 * Learn more about the project
 * Ask questions and learn from other contributors
 * Show off your work
@@ -29,6 +32,7 @@ NOTE: The live build is often several weeks or months behind the current build h
 Also consider joining the [subreddit.](https://www.reddit.com/r/EigengrausGenerator)
 
 ## Contributing :black_nib:
+
 We love getting pull requests! You can find out more about contributing to the project [here.](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/wiki/Contributing) 
 
 Once you've cloned the project, remember to `yarn` or `npm install` to install the required dependencies.
@@ -42,18 +46,19 @@ If you don't want to code, that's okay! The Generator is built out of a novel's 
 You can also find easy work to do on the generator [here.](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
 ## Deploying :cloud:
+
 To deploy the latest version, build the html file as `dist/index.html` and run either `npm run deploy`, or `yarn deploy`.
 
 ---
 
 ## Built With :hammer:
+
 * [Twine](https://twinery.org/) - The front end framework 
 * [Sugarcube 2](https://www.motoslave.net/sugarcube/2/) - A language for Twine
 * [TweeGo](https://www.motoslave.net/tweego/) - Twine command line compiler
 
-##
+---
 
 If you can't contribute pull requests consider supporting the Generator through [Patreon](https://www.patreon.com/eigengrausgenerator)
 
 We hope that you find it useful!
-

--- a/README.md
+++ b/README.md
@@ -28,28 +28,14 @@ NOTE: The live build is often several weeks or months behind the current build h
 
 Also consider joining the [subreddit.](https://www.reddit.com/r/EigengrausGenerator)
 
-## Compiling :computer:
-To compile EEEG for local testing you will need the latest version of [TweeGo](http://www.motoslave.net/tweego/) and [SugarCube](http://www.motoslave.net/sugarcube/2/). 
-```bash
-# Show TweeGo knows where the SugarCube format is
-export TWEEGO_PATH=LOCATION_OF_SUGARCUBE
-
-# go to where you installed Tweego. If you installed it globally, feel free to skip this
-cd $TWEEGO_PATH
-
-# replace PROJECT_ROOT with wherever you git cloned the repository
-tweego -o EEEG.html {PROJECT_ROOT}/EssentialEstablishmentGenerator --head={PROJECT_ROOT}/main.txt
-```
-This generates `EEEG.html` in the project root directory that you can open in a browser.
-
-NOTE: You can save time once you've set your directories by saving that command as a `.bat` or `.sh` file.
-
 ## Contributing :black_nib:
 We love getting pull requests! You can find out more about contributing to the project [here.](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/wiki/Contributing) 
 
-Once you've cloned the project, remember to `yarn` or `npm install` to install eslint.
+Once you've cloned the project, remember to `yarn` or `npm install` to install the required dependencies.
 
 Use `npm test` to run tests.
+Use `npm build` to build the output files.
+Use `npm start` to automatically rebuild on file changes.
 
 If you don't want to code, that's okay! The Generator is built out of a novel's worth of words, and we're always in need of more descriptions. You can find writing tasks [here.](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aissue+is%3Aopen+label%3AWriting)
 

--- a/main.ejs
+++ b/main.ejs
@@ -1,4 +1,3 @@
-
 <meta name="description" content="A generator unlike any other, Eigengrau's Generator procedurally generates towns and NPCs, all in paragraphs suitable to read out to players.">
 <meta name="author" content="Rhys Gray">
 <meta name="image" content="https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/tree/master/EssentialEstablishmentGenerator/Resources/example.png">

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   },
   "homepage": "https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/blob/master/README.md",
   "scripts": {
+    "postinstall": "node scripts/postinstall",
+    "build": "node scripts/build",
+    "start": "node scripts/build --watch",
     "test": "jest",
     "lint": "eslint **/*.js",
     "lint-fix": "eslint **/*.js --fix",
@@ -32,6 +35,7 @@
     ]
   },
   "devDependencies": {
+    "chalk": "^2.4.2",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.17.2",
@@ -42,6 +46,7 @@
     "gh-pages": "^2.0.1",
     "husky": "^2.3.0",
     "jest": "^24.8.0",
-    "lint-staged": "^8.1.7"
+    "lint-staged": "^8.1.7",
+    "yauzl": "^2.10.0"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,35 @@
+const path = require('path')
+const spawn = require('child_process').spawn
+const utils = require('./utils')
+
+const tweego = path.resolve(utils.twineFolder, 'tweego')
+const watch = process.argv.includes('--watch')
+
+// Run tweego with arguments.
+const tweegoProcess = spawn(
+  tweego,
+  [
+    '--output=gh-pages/index.html',
+    './EssentialEstablishmentGenerator',
+    '--head=./main.ejs',
+    watch && '--watch'
+  ]
+)
+
+// Log messages from the tweego process.
+utils.logClear()
+tweegoProcess.stderr.on('data', data => {
+  data.toString().split('\n').forEach(message => {
+    if (message.match(/^warning:\s+.*/)) {
+      utils.logWarning(message)
+      return
+    }
+
+    if (message.match(/^error:\s+.*/)) {
+      utils.logError(message)
+      return
+    }
+
+    utils.logAction(message)
+  })
+})

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,69 @@
+const path = require('path')
+const http = require('https')
+const fs = require('fs')
+const yauzl = require('yauzl')
+const utils = require('./utils')
+
+fs.mkdirSync(utils.twineFolder, { recursive: true })
+
+console.clear()
+
+const tweegoLink = getTweegoLink()
+utils.logAction('Downloading the tweego binary file from', tweegoLink)
+utils.logInfo('Copyright(c) 2014 - 2018 Thomas Michael Edwards <thomasmedwards@gmail.com>.\nAll rights reserved.')
+downloadAndExtract(tweegoLink, utils.tweegoZip)
+
+utils.logAction('Downloading the story formats from', utils.links.storyFormats)
+downloadAndExtract(utils.links.storyFormats, utils.formatsZip)
+
+function downloadAndExtract (link, filePath) {
+  const writeStream = fs.createWriteStream(filePath)
+
+  http
+    .get(link, response => response.pipe(writeStream))
+    .on('error', utils.logError)
+    .on('close', onDownloaded)
+
+  function onDownloaded () {
+    utils.logSuccess('Downloaded', filePath)
+
+    // Unzip
+    yauzl.open(filePath, { lazyEntries: true }, (error, zip) => {
+      if (error) {
+        throw error
+      }
+      utils.logAction('Unzipping...')
+      zip.readEntry()
+      zip.on('entry', entry => {
+        if (isFolder(entry)) {
+          zip.readEntry()
+          return
+        }
+        zip.openReadStream(entry, (error, stream) => {
+          if (error) {
+            throw error
+          }
+          const folder = path.resolve(utils.twineFolder, getFileDirectory(entry.fileName))
+          fs.mkdirSync(folder, { recursive: true })
+          const filePath = path.resolve(utils.twineFolder, entry.fileName)
+          const writeStream = fs.createWriteStream(filePath)
+          stream.on('end', () => zip.readEntry()).pipe(writeStream)
+        })
+      })
+    })
+  }
+}
+
+function getTweegoLink () {
+  const platform = utils.links.tweego[process.platform]
+  const link = platform[process.arch] || platform['x86']
+  return link
+}
+
+function isFolder (entry) {
+  return /\/$/.test(entry.fileName)
+}
+
+function getFileDirectory (file) {
+  return file.substring(0, file.lastIndexOf('/'))
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,52 +6,55 @@ const utils = require('./utils')
 
 fs.mkdirSync(utils.twineFolder, { recursive: true })
 
-console.clear()
-
 const tweegoLink = getTweegoLink()
+
+utils.logClear()
 utils.logAction('Downloading the tweego binary file from', tweegoLink)
 utils.logInfo('Copyright(c) 2014 - 2018 Thomas Michael Edwards <thomasmedwards@gmail.com>.\nAll rights reserved.')
-downloadAndExtract(tweegoLink, utils.tweegoZip)
 
-utils.logAction('Downloading the story formats from', utils.links.storyFormats)
-downloadAndExtract(utils.links.storyFormats, utils.formatsZip)
+downloadAndExtract(tweegoLink, utils.tweegoZip).then(() => {
+  utils.logAction('Downloading the story formats from', utils.links.storyFormats)
+
+  downloadAndExtract(utils.links.storyFormats, utils.formatsZip).then(() => {
+    utils.logSuccess('All done!')
+  })
+})
 
 function downloadAndExtract (link, filePath) {
-  const writeStream = fs.createWriteStream(filePath)
+  return new Promise((resolve, reject) => {
+    const writeStream = fs.createWriteStream(filePath)
 
-  http
-    .get(link, response => response.pipe(writeStream))
-    .on('error', utils.logError)
-    .on('close', onDownloaded)
+    http
+      .get(link, response => response.pipe(writeStream))
+      .on('error', utils.logError)
+      .on('close', unzip)
 
-  function onDownloaded () {
-    utils.logSuccess('Downloaded', filePath)
-
-    // Unzip
-    yauzl.open(filePath, { lazyEntries: true }, (error, zip) => {
-      if (error) {
-        throw error
-      }
-      utils.logAction('Unzipping...')
-      zip.readEntry()
-      zip.on('entry', entry => {
-        if (isFolder(entry)) {
-          zip.readEntry()
-          return
+    function unzip () {
+      yauzl.open(filePath, { lazyEntries: true }, (error, zip) => {
+        if (error) {
+          throw error
         }
-        zip.openReadStream(entry, (error, stream) => {
-          if (error) {
-            throw error
+        utils.logAction('Unzipping...\n')
+        zip.readEntry()
+        zip.on('entry', entry => {
+          if (isFolder(entry)) {
+            zip.readEntry()
+            return
           }
-          const folder = path.resolve(utils.twineFolder, getFileDirectory(entry.fileName))
-          fs.mkdirSync(folder, { recursive: true })
-          const filePath = path.resolve(utils.twineFolder, entry.fileName)
-          const writeStream = fs.createWriteStream(filePath)
-          stream.on('end', () => zip.readEntry()).pipe(writeStream)
-        })
+          zip.openReadStream(entry, (error, stream) => {
+            if (error) {
+              throw error
+            }
+            const fileFolder = path.resolve(utils.twineFolder, getFileDirectory(entry.fileName))
+            fs.mkdirSync(fileFolder, { recursive: true })
+            const filePath = path.resolve(utils.twineFolder, entry.fileName)
+            const writeStream = fs.createWriteStream(filePath)
+            stream.on('end', () => zip.readEntry()).pipe(writeStream)
+          })
+        }).on('end', resolve)
       })
-    })
-  }
+    }
+  })
 }
 
 function getTweegoLink () {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,58 @@
+const path = require('path')
+const chalk = require('chalk')
+
+// Folder to store the twine-related dependencies in.
+const twineFolder = path.resolve(__dirname, '..', 'node_modules', '.twine')
+
+module.exports = {
+  // Useful paths.
+  twineFolder,
+  tweegoZip: path.resolve(twineFolder, 'tweego.zip'),
+  formatsZip: path.resolve(twineFolder, 'formats.zip'),
+
+  // Various download links.
+  links: {
+    tweego: {
+      win32: {
+        x86:
+          'https://www.motoslave.net/tweego/download.php/tweego-1.3.0-windows-x86.zip',
+        x64:
+          'https://www.motoslave.net/tweego/download.php/tweego-1.3.0-windows-x64.zip'
+      },
+      darwin: {
+        x86:
+          'https://www.motoslave.net/tweego/download.php/tweego-1.3.0-macos-x86.zip',
+        x64:
+          'https://www.motoslave.net/tweego/download.php/tweego-1.3.0-macos-x64.zip'
+      },
+      linux: {
+        x86:
+          'https://www.motoslave.net/tweego/download.php/tweego-1.3.0-linux-x86.zip',
+        x64:
+          'https://www.motoslave.net/tweego/download.php/tweego-1.3.0-linux-x64.zip'
+      }
+    },
+    storyFormats:
+      'https://www.motoslave.net/tweego/download.php/story-formats-20190129.zip'
+  },
+
+  // Logging
+  logClear () {
+    console.clear()
+  },
+  logError (...args) {
+    console.log(chalk.red(...args))
+  },
+  logWarning (...args) {
+    console.log(chalk.yellow(...args))
+  },
+  logAction (...args) {
+    console.log(chalk.blue(...args))
+  },
+  logInfo (...args) {
+    console.log(chalk.grey(...args))
+  },
+  logSuccess (...args) {
+    console.log(chalk.green(...args))
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,7 +98,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.4.2":
+"@babel/runtime@^7.0.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
   integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
@@ -547,11 +547,6 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-metadata-inferer@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1.tgz#66e24fae9d30ca961fac4880b7fc466f09b25165"
-  integrity sha512-hc9w8Qrgg9Lf9iFcZVhNjUnhrd2BBpTlyCnegPVvCe6O0yMrF57a6Cmh7k+xUsfUOMh9wajOL5AsGOBNEyTCcw==
-
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -687,21 +682,17 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
-browserslist@^4.5.2:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.0.tgz#5274028c26f4d933d5b1323307c1d1da5084c9ff"
-  integrity sha512-Jk0YFwXBuMOOol8n6FhgkDzn3mY9PYLYGk29zybF05SbRTsMgPqmTNeQQhOghCxq5oFqAXE3u4sYddr4C0uRhg==
-  dependencies:
-    caniuse-lite "^1.0.30000967"
-    electron-to-chromium "^1.3.133"
-    node-releases "^1.1.19"
-
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
   integrity sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=
   dependencies:
     node-int64 "^0.4.0"
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -751,16 +742,6 @@ camelcase@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-
-caniuse-db@^1.0.30000951:
-  version "1.0.30000969"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000969.tgz#e6aeca9b1bac88865990913a0b041f587180cd59"
-  integrity sha512-ttrmwpIXvEL/kg0JSg6Q+xEbMxAEcjZOOgZMGPcMe5JMYgi20Nvs9bqMRGfyIOQtd1jYa6yRWODIR6apj3xPQw==
-
-caniuse-lite@^1.0.30000967:
-  version "1.0.30000969"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000969.tgz#7664f571f2072657bde70b00a1fc1ba41f1942a9"
-  integrity sha512-Kus0yxkoAJgVc0bax7S4gLSlFifCa7MnSZL9p9VuS/HIKEL4seaqh28KIQAAO50cD/rJ5CiJkJFapkdDAlhFxQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -1123,11 +1104,6 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-electron-to-chromium@^1.3.133:
-  version "1.3.135"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.135.tgz#f5799b95f2bcd8de17cde47d63392d83a4477041"
-  integrity sha512-xXLNstRdVsisPF3pL3H9TVZo2XkMILfqtD6RiWIUmDK2sFX1Bjwqmd8LBp0Kuo2FgKO63JXPoEVGm8WyYdwP0Q==
-
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
@@ -1215,18 +1191,6 @@ eslint-module-utils@^2.4.0:
   dependencies:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
-
-eslint-plugin-compat@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-compat/-/eslint-plugin-compat-3.1.1.tgz#5ec367dbaec422928894e6b4f708aa623f23a198"
-  integrity sha512-pqy5LBy4ZPhSVwb2p0+jUozdnoGX+qc1NRIcK+Yfg99149ncqZVc8gP5u637vwVC/nLQP6X6zTpnHwsZCdvluQ==
-  dependencies:
-    "@babel/runtime" "^7.4.2"
-    ast-metadata-inferer "^0.1.1"
-    browserslist "^4.5.2"
-    caniuse-db "^1.0.30000951"
-    mdn-browser-compat-data "^0.0.72"
-    semver "^5.6.0"
 
 eslint-plugin-es@^1.4.0:
   version "1.4.0"
@@ -1446,7 +1410,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@3.0.2, extend@~3.0.2:
+extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -1505,6 +1469,13 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+  dependencies:
+    pend "~1.2.0"
 
 figures@^1.7.0:
   version "1.7.0"
@@ -2995,13 +2966,6 @@ matcher@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.4"
 
-mdn-browser-compat-data@^0.0.72:
-  version "0.0.72"
-  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.72.tgz#b1d2026bfbf61c82e71c4157059b9d161c8791a9"
-  integrity sha512-vt3BxJRpV638ncYLigX91k0qP1VcpKxgExqPtX+QKFvV4/ZruZ31Sl35LsDDq5q+D7Lt7mfGWnCEuZ0d6bJW1g==
-  dependencies:
-    extend "3.0.2"
-
 mem@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
@@ -3208,13 +3172,6 @@ node-pre-gyp@^0.12.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
-
-node-releases@^1.1.19:
-  version "1.1.19"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.19.tgz#c492d1e381fea0350b338b646c27867e88e91b3d"
-  integrity sha512-SH/B4WwovHbulIALsQllAVwqZZD1kPmKCqrhGfR29dXjLAVZMHvBjD3S6nL9D/J9QkmZ1R92/0wCMDKXUUvyyA==
-  dependencies:
-    semver "^5.3.0"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -3559,6 +3516,11 @@ path-type@^3.0.0:
   integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
     pify "^3.0.0"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -4798,6 +4760,14 @@ yargs@^12.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yup@^0.27.0:
   version "0.27.0"


### PR DESCRIPTION
- Adds script for downloading tweego files on `postinstall`
- Adds script for simpler building
- Updates the readme.
- Converts the main file to a nicer format.

So now all you have to do is `yarn` to install everything required, and then `yarn build` or `yarn start`.
This should greatly simplify on-boarding.