### PR TITLE
Enforces let const and object shorthand

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,5 +11,10 @@
     "State": true,
     "randomFloat": true,
     "clone": true
+  },
+  "rules": {
+    "no-var": "warn",
+    "prefer-const": "warn",
+    "object-shorthand": ["warn", "always"]
   }
 }


### PR DESCRIPTION
Enables linting rules for [`no-var`](https://eslint.org/docs/rules/no-var), [`prefer-const`](https://eslint.org/docs/rules/prefer-const) & [`object-shorthand`](https://eslint.org/docs/rules/object-shorthand)