### PR TITLE
Add eslint rule for consistent qoutes on props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
   "rules": {
     "no-var": "warn",
     "prefer-const": "warn",
-    "object-shorthand": ["warn", "always"]
+    "object-shorthand": ["warn", "always"],
+    "quote-props": ["warn", "consistent-as-needed"]
   }
 }


### PR DESCRIPTION
```javascript
const obj = {
  'prop1': value // => prop1, because none of the props need quotes
  prop2: value
}
```
```javascript
const obj = {
  'prop-1': value 
  prop2: value // => 'prop2', because one of the props has a name that needs quotes
}
```