### PR TITLE
Migrate Version Number to toolbar

### DIFF
--- a/EssentialEstablishmentGenerator/Settings/CSS/stylesheet.css
+++ b/EssentialEstablishmentGenerator/Settings/CSS/stylesheet.css
@@ -11,6 +11,12 @@ body {
   margin-bottom: 4px;
   margin-top: 4px;
 }
+
+.version{
+ color: rgba(94, 72, 69, 0.651);
+ font-size: 16px;
+ margin-bottom: 10px;
+}
 #story-title{
   display: none;
 }

--- a/EssentialEstablishmentGenerator/Settings/CSS/stylesheet.css
+++ b/EssentialEstablishmentGenerator/Settings/CSS/stylesheet.css
@@ -15,7 +15,6 @@ body {
 .version{
  color: rgba(94, 72, 69, 0.651);
  font-size: 16px;
- margin-bottom: 10px;
 }
 #story-title{
   display: none;

--- a/EssentialEstablishmentGenerator/Settings/StoryStuff/StoryAuthor.twee
+++ b/EssentialEstablishmentGenerator/Settings/StoryStuff/StoryAuthor.twee
@@ -2,7 +2,7 @@
 :: StoryAuthor
 
 [img[sidebarbanner]]
-
+<span class="version">v$versionNumber</span>
 Created by /u/rcgy
 
 <<if settings.hideAds !== true or $hideAds !== true>><span class="tip" title="Thank you for your continued support!"><div id="patreon">[img[patreon][https://www.patreon.com/bePatron?u=399997]]</div></span><span class="tip" title="Thank you for your continued support!"><div id="kofi">[img[kofi][https://ko-fi.com/Q5Q8O5AA]]</div></span><span class="tip" title="Come join our community!"><div id="patreon">[img[discord][https://discord.gg/A543VC5]]</div></span><span class="tip" title="Check out the repository!"><div id="github">[img[github][https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator]]</div></span><</if>>

--- a/EssentialEstablishmentGenerator/Settings/StoryStuff/StoryMenu.twee
+++ b/EssentialEstablishmentGenerator/Settings/StoryStuff/StoryMenu.twee
@@ -25,3 +25,4 @@
 /*<<link "Check Variables">><<checkvars>><</link>>
 
 <<link "Create Bug Report">><<bugreport "Bug Report Instructions">><</link>>*/
+

--- a/EssentialEstablishmentGenerator/Start/Start.twee
+++ b/EssentialEstablishmentGenerator/Start/Start.twee
@@ -1,8 +1,6 @@
 :: Start [output]
 <span id="body">[img[banner]]
 
-<span class="firstcharacter">W</span>elcome to Eigengrau's Essential Establishment Generator, v$versionNumber! This is still in active development.
-
 <h3>Quick scenario generator</h3><<include "CreateScenario">>
 <h3>The $town.type of $town.name</h3><span class="tip" title="Find the overview of the town and its sociopolitical structure here!"><<link "Description of $town.name">><<set $currentPassage to $town>><<goto "TownOutput">><</link>></span>
 <<listbox "$newBuilding">>


### PR DESCRIPTION
This also removes the welcome message to streamline the first page and have more of the actual generator visible as soon as the user comes to the site