### PR TITLE
Tweak/docks

### DIFF
--- a/EssentialEstablishmentGenerator/Town/js/createStartBuildings.js
+++ b/EssentialEstablishmentGenerator/Town/js/createStartBuildings.js
@@ -1,7 +1,10 @@
 
 setup.createStartBuildings = function (town) {
-  const buildingType = ['townSquare', 'tavern', 'alchemist', 'GeneralStore', 'smithy', 'market', 'temple', 'docks']
+  const buildingType = ['townSquare', 'tavern', 'alchemist', 'GeneralStore', 'smithy', 'market', 'temple']
 
+  if (town.location === 'seashore' || town.location === 'river coast') {
+    buildingType.push('docks')
+  }
   if (town.hasBrothel) {
     buildingType.push('brothel')
   }

--- a/EssentialEstablishmentGenerator/Town/js/townData.js
+++ b/EssentialEstablishmentGenerator/Town/js/townData.js
@@ -846,10 +846,10 @@ setup.townData = {
           }
         }
       },
-      start: ['seacoast', 'seacoast', 'forest', 'forest', 'hills', 'plains', 'mountains', 'river coast'],
+      start: ['seashore', 'seashore', 'seashore', 'seashore', 'forest', 'forest', 'hills', 'plains', 'mountains', 'river coast', 'river coast'],
       location: {
         // town.Name is located in the _
-        'seacoast': {
+        'seashore': {
           precipitationIntensity: 3,
           // town.Name grew around _
           origin: [


### PR DESCRIPTION
This increases the chance of towns being coastal and sets docks to only naturally spawn in coastal towns. Docks can still be manually added to any town via the Create New Buildings button