### PR TITLE
Remove redundant clamp calls

### DIFF
--- a/EssentialEstablishmentGenerator/Tools/clampRolls.js
+++ b/EssentialEstablishmentGenerator/Tools/clampRolls.js
@@ -6,8 +6,6 @@
  */
 setup.clampRolls = function (rolls) {
   Object.keys(rolls).forEach(function (roll) {
-    rolls[roll].clamp(1, 100)
-    Math.clamp(rolls[roll], 1, 100)
     if (rolls[roll] > 100) {
       console.log(rolls[roll] + ' was over 100.')
       rolls[roll] = 100


### PR DESCRIPTION
The two removed lines didn't actually do anything, to the best of my knowledge.
Neither one modifies the original value.