### PR TITLE
Feature/general store tweaks

### DIFF
--- a/EssentialEstablishmentGenerator/GeneralStore/GeneralStoreOutput.twee
+++ b/EssentialEstablishmentGenerator/GeneralStore/GeneralStoreOutput.twee
@@ -1,7 +1,8 @@
 :: GeneralStoreOutput [GeneralStore]
-<<unset $selectedBuilding>><<set $GeneralStore to ($town.buildings.GeneralStore[$selected.key] || $town.buildings.GeneralStore[$currentPassage.key])>><<set $shopkeep to $npcs[$GeneralStore.shopkeep.key]>><h1>$GeneralStore.name</h1><<include "TownMicroEventsOutput">><span class="firstcharacter">Y</span>ou make your way down $GeneralStore.road, and enter $GeneralStore.structure.generalStoreDescriptor and see that inside, the $GeneralStore.size building is $GeneralStore.cleanliness. $GeneralStore.clutter
+<<unset $selectedBuilding>><<set $GeneralStore to ($town.buildings.GeneralStore[$selected.key] || $town.buildings.GeneralStore[$currentPassage.key])>><<set $shopkeep to $npcs[$GeneralStore.shopkeep.key]>><h1>$GeneralStore.name</h1><<include "TownMicroEventsOutput">><span class="firstcharacter">Y</span>ou make your way down $GeneralStore.road, and enter $GeneralStore.structure.generalStoreDescriptor and see that inside, the $GeneralStore.size building is $GeneralStore.cleanliness. $GeneralStore.clutter You notice $GeneralStore.note. The store's shopkeep is currently $GeneralStore.idle.
 
-The store's shopkeep is $GeneralStore.idle. The shopkeep <<print either($shopkeep.greeting)>> when you enter, and <<print either("saunters", "walks", "strolls", "walks", "slowly walks", "drags $shopkeep.hisher feet", "swaggers", "quickly walks", "ambles", "wanders")>> over to you. <<print $shopkeep.heshe.toUpperFirst()>> introduces $shopkeep.himherself as <<profile $shopkeep>>, the $shopkeep.owner of the General Store, and asks what $shopkeep.heshe can do for you. You notice $GeneralStore.note.
+<h3>Shopkeeper</h3>
+The shopkeep <<print either($shopkeep.greeting)>> <<print either('when you come inside', 'after finishing with another customer', 'as soon as you come through the door', 'when you come up to the counter', 'while you look around')>>. <<print $shopkeep.heshe.toUpperFirst()>> introduces $shopkeep.himherself as <<profile $shopkeep>>, the $shopkeep.owner of the General Store, and asks what $shopkeep.heshe can do for you.
 
 
 <<include "GeneralStoreSell">>

--- a/EssentialEstablishmentGenerator/GeneralStore/GeneralStoreSell.twee
+++ b/EssentialEstablishmentGenerator/GeneralStore/GeneralStoreSell.twee
@@ -32,7 +32,7 @@
     <th>Item</th>
     <th>Cost</th>
   </tr>
-<h3>Weapons</h3>
+<h6>Weapons</h6>
 <<for _i, _item range setup.inventory.filter(function (item) {
   return item.availability <= _availability
   && item.type === "weapon"
@@ -41,7 +41,7 @@
 <td><<money _item.cost>></td></tr>
 <</for>>
 
-<h3>Armour</h3>
+<h6>Armour</h6>
 <<for _i, _item range setup.inventory.filter(function (item) {
   return item.availability <= _availability
   && item.type === "armour"
@@ -50,7 +50,7 @@
 <td><<money _item.cost>></td></tr>
 <</for>>
 
-<h3>Adventuring Gear</h3>
+<h6>Adventuring Gear</h6>
 <<for _i, _item range setup.inventory.filter(function (item) {
   return item.availability <= _availability
   && item.type === "adventuring gear"
@@ -59,7 +59,7 @@
 <td><<money _item.cost>></td></tr>
 <</for>>
 
-<h3>Tools</h3>
+<h6>Tools</h6>
 <<for _i, _item range setup.inventory.filter(function (item) {
   return item.availability <= _availability
   && item.type === "tools"


### PR DESCRIPTION
Rearranges the text in the output to have the descriptors all together and the talk with the shopkeep separate with a divider to make it easy for DMs to jump around.