### PR TITLE
Feature/Temple tweaks

### DIFF
--- a/EssentialEstablishmentGenerator/MiniEstablishments/CreateTemple.js
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/CreateTemple.js
@@ -26,8 +26,9 @@ setup.createTemple = function (town, opts) {
     features: data.features.seededrandom(),
     architect: data.architect.seededrandom(),
     priestChat: '<<print $priest.heshe.toUpperFirst()>> ' + data.priestChat.seededrandom(),
-    priestLook: 'A temple priest is ' + data.priestLook.seededrandom()
-
+    priestLook: 'A temple priest is ' + data.priestLook.seededrandom(),
+    blessingConvey: data.blessingConvey.seededrandom(),
+    blessingGift: data.blessingGift.seededrandom()
   })
   setup.structure.create(town, temple)
   temple.structure.templeDescriptor = 'a ' + temple.structure.material.wealth + ' ' + temple.structure.material.noun + ' ' + temple.wordNoun + ' with a ' + temple.structure.roof.verb + ' roof'
@@ -43,7 +44,7 @@ setup.createTemple = function (town, opts) {
   temple.wealth = ''
   temple.size = ''
   temple.cleanliness = ''
-
+  temple.blessing = temple.blessingConvey + '. ' + temple.blessingGift + '.'
   const rollDataVariables = ['wealth', 'size', 'cleanliness']
   for (const propName of rollDataVariables) {
     setup.defineRollDataGetter(temple, data.rollData, propName)
@@ -52,7 +53,7 @@ setup.createTemple = function (town, opts) {
   // These are the full sentence printouts referenced within TempleOutput.twee
   temple.guardReadout = 'This ' + temple.wordNoun + ' is protected by ' + temple.guardedBy + '.'
   temple.aboutReadout = 'Within this holy place they pray to ' + temple.prayerSubject + '. The temple itself was originally dedicated to ' + temple.dedicated + ' and is known for ' + temple.knownFor + '.'
-  temple.interiorReadout = 'You enter the ' + temple.size + ', ' + temple.cleanliness + ' ' + temple.wordNoun + ' and notice ' + temple.features + '. The main room is ' + temple.floorPlan + ' in shape and is decorated with ' + temple.wealth + ' looking furniture. The interior walls of the ' + temple.wordNoun + ' are ' + temple.walls + ' and the the ceiling is ' + temple.ceiling + '. The ' + temple.wordNoun + ' was designed by ' + temple.architect + ' and it is ' + temple.complex + '.'
+  temple.interiorReadout = 'You enter the ' + temple.size + ', ' + temple.cleanliness + ' ' + temple.wordNoun + ' and notice ' + temple.features + '. The main room is ' + temple.floorPlan + ' in shape and is decorated with ' + temple.wealth + ' looking ' + ['furniture', 'pews', 'relics', 'holy statues', 'holy symbols', 'stained glass windows', 'holy art'].seededrandom() + '. The interior walls of the ' + temple.wordNoun + ' are ' + temple.walls + ' and the the ceiling is ' + temple.ceiling + '. The ' + temple.wordNoun + ' was designed by ' + temple.architect + ' and it is ' + temple.complex + '.'
   temple.tippyDescription = 'A ' + temple.size + ' and ' + temple.cleanliness + ' ' + temple.wordNoun + ' that is dedicated to ' + temple.dedicated
   return temple
 }

--- a/EssentialEstablishmentGenerator/MiniEstablishments/CreateTemple.js
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/CreateTemple.js
@@ -24,7 +24,8 @@ setup.createTemple = function (town, opts) {
     ceiling: data.ceiling.seededrandom(),
     rooms: data.rooms.seededrandom(),
     features: data.features.seededrandom(),
-    architect: data.architect.seededrandom()
+    architect: data.architect.seededrandom(),
+    priestChat: '<<print $priest.heshe.toUpperFirst()>> ' + data.priestChat.seededrandom()
 
   })
   setup.structure.create(town, temple)
@@ -49,8 +50,8 @@ setup.createTemple = function (town, opts) {
 
   // These are the full sentence printouts referenced within TempleOutput.twee
   temple.guardReadout = 'This ' + temple.wordNoun + ' is protected by ' + temple.guardedBy + '.'
-  temple.aboutReadout = 'Within this holy place they pray to ' + temple.prayerSubject + '. The temple itself was originally dedicated to ' + temple.dedicated + ' and is known for ' + temple.knownFor + '. The ' + temple.wordNoun + ' was designed by ' + temple.architect + ' and it is ' + temple.complex + '.'
-  temple.interiorReadout = 'You enter the ' + temple.size + ', ' + temple.cleanliness + ' ' + temple.wordNoun + ' and notice ' + temple.features + '. The main room is ' + temple.floorPlan + ' in shape and is decorated with ' + temple.wealth + ' looking furniture. The interior walls of the ' + temple.wordNoun + ' are ' + temple.walls + ' and the the ceiling is ' + temple.ceiling + '.'
+  temple.aboutReadout = 'Within this holy place they pray to ' + temple.prayerSubject + '. The temple itself was originally dedicated to ' + temple.dedicated + ' and is known for ' + temple.knownFor + '.'
+  temple.interiorReadout = 'You enter the ' + temple.size + ', ' + temple.cleanliness + ' ' + temple.wordNoun + ' and notice ' + temple.features + '. The main room is ' + temple.floorPlan + ' in shape and is decorated with ' + temple.wealth + ' looking furniture. The interior walls of the ' + temple.wordNoun + ' are ' + temple.walls + ' and the the ceiling is ' + temple.ceiling + '. The ' + temple.wordNoun + ' was designed by ' + temple.architect + ' and it is ' + temple.complex + '.'
   temple.tippyDescription = 'A ' + temple.size + ' and ' + temple.cleanliness + ' ' + temple.wordNoun + ' that is dedicated to ' + temple.dedicated
   return temple
 }

--- a/EssentialEstablishmentGenerator/MiniEstablishments/CreateTemple.js
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/CreateTemple.js
@@ -25,7 +25,8 @@ setup.createTemple = function (town, opts) {
     rooms: data.rooms.seededrandom(),
     features: data.features.seededrandom(),
     architect: data.architect.seededrandom(),
-    priestChat: '<<print $priest.heshe.toUpperFirst()>> ' + data.priestChat.seededrandom()
+    priestChat: '<<print $priest.heshe.toUpperFirst()>> ' + data.priestChat.seededrandom(),
+    priestLook: 'A temple priest is ' + data.priestLook.seededrandom()
 
   })
   setup.structure.create(town, temple)

--- a/EssentialEstablishmentGenerator/MiniEstablishments/TempleOutput.twee
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/TempleOutput.twee
@@ -5,7 +5,8 @@ $temple.interiorReadout
 $temple.aboutReadout
 
 <h3>Priest</h3>
-A priest greets you, and introduces $priest.himherself as <<profile $priest>>. $temple.priestChat.
+$temple.priestLook.
+The priest greets you, and introduces $priest.himherself as <<profile $priest>>. $temple.priestChat.
 
 <<nobr>><<linkappend "<h4>Buy something</h4>" t8n>>
 
@@ -26,7 +27,7 @@ A priest greets you, and introduces $priest.himherself as <<profile $priest>>. $
     <th>Item</th>
     <th>Cost</th>
   </tr>
-<h3>Adventuring Gear</h3>
+<h6>Adventuring Gear</h6>
 <<for _i, _item range setup.inventory.filter(function (item) {
   return item.availability <= _availability
   && item.type === "adventuring gear"
@@ -35,7 +36,7 @@ A priest greets you, and introduces $priest.himherself as <<profile $priest>>. $
 <td><<money _item.cost>></td></tr>
 <</for>>
 
-<h3>Tools</h3>
+<h6>Tools</h6>
 <<for _i, _item range setup.inventory.filter(function (item) {
   return item.availability <= _availability
   && item.type === "tools"

--- a/EssentialEstablishmentGenerator/MiniEstablishments/TempleOutput.twee
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/TempleOutput.twee
@@ -9,7 +9,7 @@ $temple.priestLook.
 The priest greets you, and introduces $priest.himherself as <<profile $priest>>. $temple.priestChat.
 <<linkreplace "<h4>Get Temple Blessing</h4>" t8n>>
 <h6>Blessing</h6>
-$temple.blessing<</linkreplace>>
+<div class="descriptive">$temple.blessing</div><</linkreplace>>
 <<nobr>><<linkappend "<h4>Buy something</h4>" t8n>>
 
 <<switch $town.type>>

--- a/EssentialEstablishmentGenerator/MiniEstablishments/TempleOutput.twee
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/TempleOutput.twee
@@ -2,12 +2,14 @@
 <<unset $selectedBuilding>><<set $temple to ($town.buildings.temple[$selected.key] || $town.buildings.temple[$currentPassage.key])>><<set $priest to $npcs[$temple.priest.key]>>
 <h1>$temple.name</h1><<include "TownMicroEventsOutput">><span class="firstcharacter">Y</span>ou come across $temple.structure.templeDescriptor. <<print either($temple.guardReadout, "", "", "", "", "", "", "", "", "",)>>
 $temple.interiorReadout
-$temple.aboutReadout
+<br>$temple.aboutReadout
 
 <h3>Priest</h3>
 $temple.priestLook.
 The priest greets you, and introduces $priest.himherself as <<profile $priest>>. $temple.priestChat.
-
+<<linkreplace "<h4>Get Temple Blessing</h4>" t8n>>
+<h6>Blessing</h6>
+$temple.blessing<</linkreplace>>
 <<nobr>><<linkappend "<h4>Buy something</h4>" t8n>>
 
 <<switch $town.type>>

--- a/EssentialEstablishmentGenerator/MiniEstablishments/TempleOutput.twee
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/TempleOutput.twee
@@ -1,11 +1,11 @@
 :: TempleOutput
 <<unset $selectedBuilding>><<set $temple to ($town.buildings.temple[$selected.key] || $town.buildings.temple[$currentPassage.key])>><<set $priest to $npcs[$temple.priest.key]>>
 <h1>$temple.name</h1><<include "TownMicroEventsOutput">><span class="firstcharacter">Y</span>ou come across $temple.structure.templeDescriptor. <<print either($temple.guardReadout, "", "", "", "", "", "", "", "", "",)>>
+$temple.interiorReadout
+$temple.aboutReadout
 
-<br> $temple.aboutReadout
-<br> $temple.interiorReadout
-
-A priest greets you, and introduces $priest.himherself as <<profile $priest>>.
+<h3>Priest</h3>
+A priest greets you, and introduces $priest.himherself as <<profile $priest>>. $temple.priestChat.
 
 <<nobr>><<linkappend "<h4>Buy something</h4>" t8n>>
 

--- a/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
@@ -289,5 +289,31 @@ setup.temple = {
     'large stone stairs leading down to a pool of clear water',
     'pillars carved with intricate images of the heavens',
     'floor tiles made of red sandstone'
+  ],
+  priestChat: [
+    // The priest ___
+    'says there are beds in a backroom that you all can use for a night if you need',
+    'tells you they are holding mass soon and you are welcome to join',
+    'says you can light a candle to honor a fallen soul for only 5 copper',
+    'softly says you are free to confess your sins here',
+    'informs you the temple has confessionals open if you wish to confess',
+    'tells you donations are always welcome if you feel generous',
+    'says you all can stay as long as you please in this holy house',
+    'says that the temple will bless you for a small price',
+    'says that $priest.heshe will bless your weapons for a small price, but you must not tell anyone',
+    'tells you the church must close at dark but you can stay until then',
+    'asks you if you have come to see the holy relic',
+    'asks what the church can do for you today',
+    'asks that you stay very quiet while visiting today',
+    'slyly brings a donation basket when $priest.heshe comes to chat',
+    'tells you the main priest is gone today, but that $priest.heshe can also give blessings',
+    'says that there is a free meal being offered to all who enter, and offers you some soup',
+    'asks you to remove your shoes and place them by the door',
+    'hands you hand-made pamphlets about the religion of the temple',
+    'says you can not stay long here today as mass is starting soon',
+    'says you must leave soon as a ritual is beginning',
+    'offers for you all to join in on a ritual that is happening in the temple soon',
+    'requests that you change into sets of white robes if you are going to remain here for long',
+    'warns you that holy spirits reside in this temple, and if you do not respect them you will anger them'
   ]
 }

--- a/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
@@ -314,6 +314,14 @@ setup.temple = {
     'says you must leave soon as a ritual is beginning',
     'offers for you all to join in on a ritual that is happening in the temple soon',
     'requests that you change into sets of white robes if you are going to remain here for long',
-    'warns you that holy spirits reside in this temple, and if you do not respect them you will anger them'
+    'warns you that holy spirits reside in this temple, and if you do not respect them you will anger them',
+    'tells you there are beds in a room below the temple and you are welcome to them',
+    'offers you a cracker from a small wicker basker',
+    'asks if you are need of any excorcisms on this visit',
+    'claims $priest.heshe has minor relics that can be sold to you',
+    'offers you each a candle to light for your prayer to be heard',
+    'says your weapons must be left in a chest by the door',
+    'tells you not to touch any of the holy items in the temple',
+    'asks if you have come for a blessing of some kind'
   ]
 }

--- a/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
@@ -362,6 +362,8 @@ setup.temple = {
   blessingGift: [
     'Afterwards, the priest tells you that you have been blessed with <<print ["["holy sight", "holy strength", "holy movement", "holy skill", "holy power", "holy light", "a holy spirit", "true sight", "a pure heart"].seededrandom() but does not explain what that means", "a healthy body", "an ever healing body for the next few hours", "a feeling of weightlessness"].seededrandom()>>',
     'The priest tells you that you were gifted <<print ["underwater breathing", "pure luck", "perfect aim", "silent steps", "strength above strength", "a link with the temple god", "an angelic glow"].seededrandom()>> for the next few hours',
-    'Afterwards, $priest.firstName apologizes and says the blessing failed'
+    'Afterwards, $priest.firstName apologizes and says the blessing failed',
+    'After all that the priest tells you that <<print ["your body has become heat resistant", "your body will feel no cold", "you can now sense evil", "you can now see in the dark", "your fighting skills will be better", "you will feel true empathy"].seededrandom()>> for the next day or so',
+    "You're told that the temple patron will now be watching over you, but it's unclear what that really means"
   ]
 }

--- a/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
@@ -349,15 +349,16 @@ setup.temple = {
     'seemingly talking to the open air as no one is around $priest.himher'
   ],
   blessingConvey: [
-    'The priest raises their hand above you and mumbles some words in a language you do not understand',
-    '$priest.firstName touches their finger to your head and whispers something quietly',
+    'The priest raises $priest.hisher hand above you and mumbles some words in a language you do not understand',
+    '$priest.firstName touches $priest.hisher finger to your head and whispers something quietly',
     'The priest walks in circles around your holding an incense lamp and chanting something quietly',
     '$priest.firstName pours water over your face from a small wooden basin while chanting a holy verse',
     '$priest.firstName pours water over your body from a large stone goblet while whispering an ancient blessing',
     'The priest takes a small cup of paint and draws lines across your face while whispering something in a holy language',
     'The priest has you drink a liquid out of a wooden cup while murmuring some sort of prayer',
     '$priest.firstName draws a holy symbol around you on the ground in chalk while chanting loudly',
-    'The priest paints holy symbols on your palms and then holds your hands while murmuring a prayer'
+    'The priest paints holy symbols on your palms and then holds your hands while murmuring a prayer',
+    'The priest places you in front of a window that has light streaming through it and recites and ancient holy phrase'
   ],
   blessingGift: [
     'Afterwards, the priest tells you that you have been blessed with <<print ["["holy sight", "holy strength", "holy movement", "holy skill", "holy power", "holy light", "a holy spirit", "true sight", "a pure heart"].seededrandom() but does not explain what that means", "a healthy body", "an ever healing body for the next few hours", "a feeling of weightlessness"].seededrandom()>>',

--- a/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
@@ -323,5 +323,29 @@ setup.temple = {
     'says your weapons must be left in a chest by the door',
     'tells you not to touch any of the holy items in the temple',
     'asks if you have come for a blessing of some kind'
+  ],
+  priestLook: [
+    // A temple priest is ___
+    'currently placing some nice smelling incense in <<print ["an old looking", "an ornate", "a cheap looking", "an animal shaped", "a wooden", "a stone", "a golden", "a bronze", "a dirty looking", "a holy"].seededrandom()>> incense holder',
+    'kneeling in front of a <<print ["small wooden statue", "small stone statue", "small basin of water", "large basin of water", "large wooden statue", "large group of melting candles", "blazing fire", "picture of the temple god", "holy book of the temple", "row of pews"].seededrandom()>> and murmuring a prayer of some kind',
+    'dusting of one of the temple pews with a small fathered brush',
+    'blessing a small basin of water at the front of the temple',
+    'lighting a candle and placing it among a large row of candles',
+    'sitting in one of the pews whispering a prayer',
+    'wearing a large flowing cloak over $priest.hisher clothes',
+    'talking with one of the temple followers',
+    'running through $priest.hisher lines for an upcoming mass',
+    'coming out from a door at the back of the temple',
+    'ringing a small bell and humming quietly',
+    'pouring some sort of liquid into a large number of small cups on a table at the front of the temple',
+    'doing some kind of work on the temple organ',
+    'wearing a large and elaborate headpiece',
+    'standing on a plinth with $priest.hisher hands raised towards the sky',
+    'reading out of a musty looking tome',
+    'starting to doze off in one of the pews',
+    'placing hymnals on every pew of the temple',
+    'relighting the torches that are scattered around the temple',
+    'polishing the brass candlesticks at the front of the temple',
+    'seemingly talking to the open air as no one is around $priest.himher'
   ]
 }

--- a/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
+++ b/EssentialEstablishmentGenerator/MiniEstablishments/templeData.js
@@ -347,5 +347,21 @@ setup.temple = {
     'relighting the torches that are scattered around the temple',
     'polishing the brass candlesticks at the front of the temple',
     'seemingly talking to the open air as no one is around $priest.himher'
+  ],
+  blessingConvey: [
+    'The priest raises their hand above you and mumbles some words in a language you do not understand',
+    '$priest.firstName touches their finger to your head and whispers something quietly',
+    'The priest walks in circles around your holding an incense lamp and chanting something quietly',
+    '$priest.firstName pours water over your face from a small wooden basin while chanting a holy verse',
+    '$priest.firstName pours water over your body from a large stone goblet while whispering an ancient blessing',
+    'The priest takes a small cup of paint and draws lines across your face while whispering something in a holy language',
+    'The priest has you drink a liquid out of a wooden cup while murmuring some sort of prayer',
+    '$priest.firstName draws a holy symbol around you on the ground in chalk while chanting loudly',
+    'The priest paints holy symbols on your palms and then holds your hands while murmuring a prayer'
+  ],
+  blessingGift: [
+    'Afterwards, the priest tells you that you have been blessed with <<print ["["holy sight", "holy strength", "holy movement", "holy skill", "holy power", "holy light", "a holy spirit", "true sight", "a pure heart"].seededrandom() but does not explain what that means", "a healthy body", "an ever healing body for the next few hours", "a feeling of weightlessness"].seededrandom()>>',
+    'The priest tells you that you were gifted <<print ["underwater breathing", "pure luck", "perfect aim", "silent steps", "strength above strength", "a link with the temple god", "an angelic glow"].seededrandom()>> for the next few hours',
+    'Afterwards, $priest.firstName apologizes and says the blessing failed'
   ]
 }


### PR DESCRIPTION
This rearranges the output text to have the descriptors read first and then have the priest below a subheader so DMs can quickly jump between them.
Also adds priestChat and priestLook these just expand the potential of the temples and gives the priest more to do than just exist and say hello.
Also adds temple blessings, very simple for now.