### PR TITLE
Fixes tests for case-sensitive filesystem + fixes for...of on object

### DIFF
--- a/EssentialEstablishmentGenerator/GeneralStore/JS/generalStoreRenders.js
+++ b/EssentialEstablishmentGenerator/GeneralStore/JS/generalStoreRenders.js
@@ -74,7 +74,7 @@ setup.generalStoreRenders = function (generalStore) {
     ].reverse()
   }
   // actually add attributes to store object
-  for (const key of attributes) {
+  for (const key in attributes) {
     const array = attributes[key]
     generalStore[key] = array[0][1] // default value
     for (const [num, descript] of array) { // update value

--- a/__tests__/GeneralStoreRenders.test.js
+++ b/__tests__/GeneralStoreRenders.test.js
@@ -1,7 +1,7 @@
 // Attaches itself to the *global* node object.
 global.setup = {}
 global.random = (min, max) => { return (min + max) / 2 } // mock random global func to be deterministic
-require('../EssentialEstablishmentGenerator/GeneralStore/JS/GeneralStoreRenders')
+require('../EssentialEstablishmentGenerator/GeneralStore/JS/generalStoreRenders')
 
 const store = {
   roll: {


### PR DESCRIPTION
In case of case sensitive filesystem (eg linux) the require call would fail.
After fixing it you would get an error as [Objects are not iterable with for of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/is_not_iterable), this PR fixes both issues.