### PR TITLE
Fixes GeneralStoreRenders test on Linux

### DIFF
--- a/__tests__/GeneralStoreRenders.test.js
+++ b/__tests__/GeneralStoreRenders.test.js
@@ -1,7 +1,7 @@
 // Attaches itself to the *global* node object.
 global.setup = {}
 global.random = (min, max) => { return (min + max) / 2 } // mock random global func to be deterministic
-require('../EssentialEstablishmentGenerator/GeneralStore/JS/GeneralStoreRenders')
+require('../EssentialEstablishmentGenerator/GeneralStore/JS/generalStoreRenders')
 
 const store = {
   roll: {


### PR DESCRIPTION
File names are case sensitive on Linux, causing: 

```bash
$ yarn test
yarn run v1.19.0
$ jest
 FAIL  __tests__/GeneralStoreRenders.test.js
  ● Test suite failed to run

    Cannot find module '../EssentialEstablishmentGenerator/GeneralStore/JS/GeneralStoreRenders' from 'GeneralStoreRenders.test.js'

      2 | global.setup = {}
      3 | global.random = (min, max) => { return (min + max) / 2 } // mock random global func to be deterministic
    > 4 | require('../EssentialEstablishmentGenerator/GeneralStore/JS/GeneralStoreRenders')
        | ^
      5 | 
      6 | const store = {
      7 |   roll: {

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:259:17)
      at Object.require (__tests__/GeneralStoreRenders.test.js:4:1)

```

**Note**: Depends on https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/pull/237 for a successful run.