### PR TITLE
Fixed the generator not loading

### DIFF
--- a/EssentialEstablishmentGenerator/Settings/StoryStuff/StoryTitle.twee
+++ b/EssentialEstablishmentGenerator/Settings/StoryStuff/StoryTitle.twee
@@ -1,4 +1,2 @@
-
 :: StoryTitle
-
 Eigengrau's Generator


### PR DESCRIPTION
Fixed https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues/239.
Newlines in StoryTitle.twee caused an unexpected line break in the JS source code.