### PR TITLE
Add twine syntax highlighting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["fabiospampinato.vscode-highlight"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,17 @@
 {
-    "deepscan.enable": true,
-    "editor.formatOnSave": false,
+  "deepscan.enable": true,
+  "editor.formatOnSave": false,
+  "highlight.maxMatches": 250,
+  "highlight.regexes": {
+    // Match things like $object.value.
+    "(\\$(\\w|\\d|\\.)+)": {
+      "filterFileRegex": ".*\\.(js|json|twee)$",
+      "decorations": [{ "color": "rgba(120, 180, 255)" }]
+    },
+    // Match things like <<print $name>>.
+    "(<<.+>>)": {
+      "filterFileRegex": ".*\\.(js|json|twee)$",
+      "decorations": [{ "color": "rgb(255, 170, 90)" }]
+    }
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
       "decorations": [{ "color": "rgba(120, 180, 255)" }]
     },
     // Match things like <<print $name>>.
-    "(<<.+>>)": {
+    "(<<(.|\n|\r)*>>)": {
       "filterFileRegex": ".*\\.(js|json|twee)$",
       "decorations": [{ "color": "rgb(255, 200, 100)" }]
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
     // Match things like <<print $name>>.
     "(<<.+>>)": {
       "filterFileRegex": ".*\\.(js|json|twee)$",
-      "decorations": [{ "color": "rgb(255, 170, 90)" }]
+      "decorations": [{ "color": "rgb(255, 200, 100)" }]
     }
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
   "editor.formatOnSave": false,
   "highlight.maxMatches": 250,
   "highlight.regexes": {
-    // Match things like $object.value.
-    "(\\$(\\w|\\d|\\.)+)": {
+    // Match things like $object.deep.value.
+    "(\\$\\w+(\\.\\w+)*)": {
       "filterFileRegex": ".*\\.(js|json|twee)$",
       "decorations": [{ "color": "rgba(120, 180, 255)" }]
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,8 @@
       "decorations": [{ "color": "rgba(120, 180, 255)" }]
     },
     // Match things like <<print $name>>.
-    "(<<(.|\n|\r)*>>)": {
+    // Respects line breaks.
+    "(<<[\\s\\S]+?>>)": {
       "filterFileRegex": ".*\\.(js|json|twee)$",
       "decorations": [{ "color": "rgb(255, 200, 100)" }]
     }


### PR DESCRIPTION
Adds some very basic syntax highlighting for twine. Requires the `Highlight` extension for VSCode.