### PR TITLE
Improve editor experience

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,19 +4,9 @@
     "browser": true,
     "jest": true
   },
-  "globals": {
-    "setup": true,
-    "random": true,
-    "dice": true,
-    "State": true,
-    "randomFloat": true,
-    "clone": true,
-    "settings": true,
-    "tippy": true,
-    "$": true
-  },
   "rules": {
     "no-var": "warn",
+    "no-undef": "off",
     "prefer-const": "warn",
     "object-shorthand": ["warn", "always"],
     "quote-props": ["warn", "consistent-as-needed"]

--- a/global.d.ts
+++ b/global.d.ts
@@ -99,6 +99,22 @@ interface Math {
   clamp(num: number, min: number, max: number): number
 }
 
+const Config: any
+
+const Dialog: any
+
+const Engine: any
+
+const jQuery: any
+
+const Macro: any
+
+const Passage: any
+
+const Save: any
+
+const Setting: any
+
 const settings: any
 
 const setup: any

--- a/global.d.ts
+++ b/global.d.ts
@@ -115,7 +115,11 @@ const Setting: any
 
 const settings: any
 
-const setup: any
+interface Setup {
+  [key: string]: any
+}
+
+const setup: Setup
 
 const State: any
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -105,8 +105,6 @@ const Dialog: any
 
 const Engine: any
 
-const jQuery: any
-
 const Macro: any
 
 const Passage: any
@@ -120,6 +118,14 @@ const settings: any
 const setup: any
 
 const State: any
+
+/*
+ * SugarCube jQuery extensions.
+ * See https://github.com/tmedwards/sugarcube-2/blob/master/src/lib/jquery-plugins.js
+ */
+interface JQueryStatic {
+  wiki(...sources): JQueryStatic
+}
 
 /*
  * Other plugins & global functions

--- a/global.d.ts
+++ b/global.d.ts
@@ -131,6 +131,11 @@ interface JQueryStatic {
  * Other plugins & global functions
  */
 
+interface Math {
+  fm(a: number, b:number): number
+  fairmath(a: number, b:number): number
+}
+
 interface Array<T> {
   seededrandom(): T
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,119 @@
+/*
+ * SugarCube v2
+ * https://www.motoslave.net/sugarcube/2/docs
+ */
+
+function clone(original: T): T
+
+function either(...list: any[]): any
+
+function forget(key: string): void
+
+function hasVisited(...passages: string[]): boolean
+
+function lastVisited(...passages: string[]): integer
+
+function importScripts(...urls: string[]): Promise<any>
+
+function importStyles(...urls: string[]): Promise<any>
+
+function memorize(key: string, value: any): void
+
+function passage(): string
+
+function previous(): string
+
+function random(max: number): number
+function random(min: number, max: number): number
+
+function randomFloat(max: number): number
+function randomFloat(min: number, max: number): number
+
+function recall(key: string, defaultValue?: any): any
+
+function setPageElement(idOrElement: string | HTMLElement, passages: string | string[], defaultText?: string): Record<any, any> | null
+
+function tags(...passages?: string[]): string[]
+
+function temporary(): Record<any, any>
+
+function time(): number
+
+function turns(): number
+
+function variables(): Record<any, any>
+
+function visited(): Record<any, any>
+
+function visitedTags(...tags: string[]): number
+
+interface Array<T> {
+  concat(...members: T[]): T[]
+  concatUnique(...members: T[]): T[]
+  count(needle: T, position?: number): number
+  delete(...needles: T[]): T[]
+  deleteAt(...indices: number[]): T[]
+  deleteWith(predicate: (value: T, index?: number, array?: T[]) => boolean, thisArg: any): T[]
+  first(): T
+  // native: flat
+  // native: flatMap
+  // native: includes
+  includesAll(needle: T, position?: number): boolean
+  includesAny(...needles: T[]): boolean
+  last(): T
+  pluck(): T
+  pluckMany(want: number): T[]
+  // native: pop
+  // native: push
+  pushUnique(...members: T[]): number
+  random(): T
+  randomMany(want: number): T[]
+  // native: shift
+  shuffle(): T[]
+  // native: unshift
+  unshiftUnique(...members: T[]): number
+}
+
+interface Number {
+  clamp(min: number, max: number): number
+}
+
+interface RegExpConstructor {
+  escape(text: string): string
+}
+
+interface StringConstructor {
+  format(format: string, ...arguments: any): string 
+}
+
+interface String {
+  count(needle: string, position?: number): number
+  first(): string
+  // native: includes
+  last(): string
+  toLocaleUpperFirst(): string
+  toUpperFirst(): string
+}
+
+interface Math {
+  clamp(num: number, min: number, max: number): number
+}
+
+const settings: any
+
+const setup: any
+
+const State: any
+
+/*
+ * Other plugins & global functions
+ */
+
+interface Array<T> {
+  seededrandom(): T
+}
+
+function dice(a: string): number
+function dice(a: number, b: number): number
+
+function tippy(selector: string): any

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "module": "none",
+    "target": "esnext",
+    "lib": ["dom", "esnext"],
+  },
+  "exclude": ["node_modules", "**/Settings/**/*"]
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,7 +3,8 @@
     "checkJs": true,
     "module": "none",
     "target": "esnext",
-    "lib": ["dom", "esnext"]
+    "lib": ["dom", "esnext"],
+    "strict": true
   },
   "exclude": ["node_modules"]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -5,5 +5,5 @@
     "target": "esnext",
     "lib": ["dom", "esnext"]
   },
-  "exclude": ["node_modules", "**/Settings/**/*"]
+  "exclude": ["node_modules"]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,7 +3,7 @@
     "checkJs": true,
     "module": "none",
     "target": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": ["dom", "esnext"]
   },
   "exclude": ["node_modules", "**/Settings/**/*"]
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     ]
   },
   "devDependencies": {
+    "@types/jquery": "^3.3.38",
     "chalk": "^2.4.2",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",

--- a/src/Buildings/buildingData.js
+++ b/src/Buildings/buildingData.js
@@ -1,4 +1,3 @@
-
 setup.structure = {
   create (town, building, opts) {
     console.groupCollapsed(`Creating the structure for ${setup.articles.output(building.wordNoun || 'building')}`)

--- a/src/setup.d.ts
+++ b/src/setup.d.ts
@@ -1,0 +1,26 @@
+interface Setup {
+  alchemist: {
+    rollData: {
+      wealth: [number, string][]
+      size: [number, string][]
+      cleanliness: [number, string][]
+      expertise: [number, string][]
+    }
+    get: {
+      lookAround(alchemist: any): {
+        cleanliness: number
+        wealth: number
+        note: string
+      }[]
+      priceTalk(alchemist: any): {
+        priceModifier: number
+        wealth: number
+        priceTalk: string
+      }[]
+    }
+  }
+  alchemistModifiers(alchemist: any): any
+  createAlchemist(alchemist: any): boolean
+  createAlchemistName(alchemistFirstName: string): string
+  createChemist(town: any): any
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,6 +412,13 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jquery@^3.3.38":
+  version "3.3.38"
+  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.38.tgz#6385f1e1b30bd2bff55ae8ee75ea42a999cc3608"
+  integrity sha512-nkDvmx7x/6kDM5guu/YpXkGZ/Xj/IwGiLDdKM99YA5Vag7pjGyTJ8BNUh/6hxEn/sEu5DKtyRgnONJ7EmOoKrA==
+  dependencies:
+    "@types/sizzle" "*"
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -421,6 +428,11 @@
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
+"@types/sizzle@*":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
+  integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
Adds type declarations for non-native methods/functions/constants. This totally replaces the old eslint globals flags.

Enables adding type declarations for properties on the `setup` object.
(see `./src/setup.d.ts` for en example)

This has the potential to catch a lot of bugs resulting from typos, as well as abstracting types to a singe source of truth. This also has some very convenient side effects, such as being able to rename things globally with a single key stroke. To try this out, see `./src/setup.d.ts` again and rename something with `F2` in VSCode.