### PR TITLE
#312 - fix

### DIFF
--- a/lib/npc-generation/setAge.ts
+++ b/lib/npc-generation/setAge.ts
@@ -8,7 +8,7 @@ export function setAge (npc: NPC): void{
 
   if (typeof ageDescriptors !== 'undefined') {
     for (const [ageThreshold, ageDescriptor] of ageDescriptors) {
-      if (ageThreshold <= npc.ageYears) {
+      if (ageThreshold >= npc.ageYears) {
         npc.age = ageDescriptor
       }
     }


### PR DESCRIPTION
#312 Age descriptors are broken in the compiled version (all NPCs show as newborn)

This was a simple comparison error. It loops through the age threshold in descending order, but was looking for the threshold to be less than the NPC age. This was always true for newborn. I simply switched the comparison direction. Not sure why it doesn't cause an issue in the live version (as of 8/25/2020). But a simple fix.


