### PR TITLE
Add check in build script that tweego was installed

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('fs')
 const path = require('path')
 const spawn = require('child_process').spawn
 const utils = require('./utils')
@@ -7,6 +8,12 @@ const webpack = require('webpack')
 utils.logClear()
 
 const tweego = path.resolve(utils.twineFolder, 'tweego')
+if (!fs.existsSync(tweego)) {
+  utils.logError('Cannot find path to tweego.')
+  utils.logError('Perhaps tweego has not been downloaded.')
+  utils.logError('Try running `yarn install-compiler` first.')
+  process.exit(1)
+}
 
 // Extract extra arguments.
 const [, , ...flags] = process.argv


### PR DESCRIPTION
After a hasty readthrough of the README, I ran the start before installing the compiler and received an assortment of errors. Adding this brief check at the start of the build script will help catch any developer that makes the same mistake.