### PR TITLE
Add executable permissions check for tweego on Unix systems

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -9,6 +9,7 @@ utils.logClear()
 
 const tweego = path.resolve(utils.twineFolder, 'tweego')
 
+// Verify correct tweego installation
 if (!fs.existsSync(tweego) && !fs.existsSync(`${tweego}.exe`)) {
   utils.logError('Cannot find path to tweego.')
   utils.logError('Perhaps tweego has not been downloaded.')
@@ -16,6 +17,16 @@ if (!fs.existsSync(tweego) && !fs.existsSync(`${tweego}.exe`)) {
   process.exit(1)
 }
 
+// Verify executable permissions on unix systems.
+if (['linux', 'darwin'].includes(process.platform)) {
+  try {
+    fs.accessSync(tweego, fs.constants.X_OK)
+  } catch (err) {
+    utils.logError(`${tweego} does not have permissions to execute.
+    If you are on a Unix-based system you can grant permissions with 'chmod +x ${tweego}'`)
+    process.exit(1)
+  }
+}
 // Extract extra arguments.
 const [, , ...flags] = process.argv
 


### PR DESCRIPTION
## What does this do?

I pulled this project and tried building it, but ran into some cryptic errors when running the `build.js` script. It turns out the problem was that the executable at `.twine/tweego` did not have permissions to execute on my machine.

This Pull Request adds a check at the top of the build.js script to provide a more user friendly error and a recommended solution.

<img width="1202" alt="Screen Shot 2020-10-15 at 3 01 13 PM" src="https://user-images.githubusercontent.com/3630241/96174851-f1b7d600-0ef7-11eb-9d53-199fd7b55ace.png">


## How was this tested?

I ran `chmod -x .twine/tweego` and verified that the process halted and displayed my error message. I then ran `chmod +x .twine/tweego` and verified that the process continues along happily.

⚠️This solution has only been tested on a macbook. I suspect this won't work properly on Windows machines. I could use some help with suggestions for how to make it windows friendly if that is something this project cares about!

## Is there a [GitHub Issue](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aopen+is%3Aissue) that this is resolving?

I don't think so.

## We are shifting from a GPL3 license to MIT. Are you okay with us relicensing your code contributions under this new license?

Yep