### PR TITLE
Replace fallback value with error in weightRandom

### DIFF
--- a/lib/src/weightRandom.ts
+++ b/lib/src/weightRandom.ts
@@ -21,6 +21,5 @@ export function weightRandom <T extends string> (specs: WeightRecord<T>): T {
     if (value <= sum) return prop
   }
 
-  // Should never happen, purely for type safety
-  return specsKeys[specsKeys.length - 1]
+  throw new Error('Invalid random roll.')
 }


### PR DESCRIPTION
## What does this do?

Improves the handling of unexpected weighted random rolls, as discussed [here](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/pull/352#discussion_r502205574).

## How was this tested?

```js
for (let i = 0; i <= 1000000; i++) {
  weightRandom({ a: 1, b: 2, c: 3 })
}

// No errors were thrown
```

## Is there a [GitHub Issue](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aopen+is%3Aissue) that this is resolving?

No.

## We are shifting from a GPL3 license to MIT. Are you okay with us relicensing your code contributions under this new license?

Yes.