### PR TITLE
Adds TS/Rollup module path configuration.

### DIFF
--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -26,7 +26,8 @@ module.exports = [
   {
     input: 'src/main.ts',
     plugins,
-    output: { file: 'src/init.js', format: 'iife' }
+    external: ['@lib'],
+    output: { file: 'src/init.js', format: 'iife', globals: { '@lib': 'lib' } }
   },
   {
     input: 'lib/index.ts',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,11 @@
     "noEmit": true,
     "allowSyntheticDefaultImports": true,
     "lib": ["dom", "esnext"],
+    "baseUrl": "./",
+    "paths": {
+      "@lib": ["./lib/index.ts"],
+      "@lib/types": ["./lib/types.ts"]
+    }
   },
   "exclude": ["node_modules", "gh-pages", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
I realized shortly after checking out this branch that a typical import/export strategy won't work especially well here. Specifically, while a relative import will "work", it'll also import the code from that module into `main.js` regardless of whether or not it's already being included in the `lib` file. That could lead to a lot of inadvertent duplication.

So, to head this off, I've updated the Rollup and TypeScript configuration to include a path alias for a `@lib` module that points to the `lib` global introduced by that file.

```typescript
import { bandits } from '@lib';                           // yay
import { bandits } from '../../../lib/constructs/bandits' // nay, duplicates code
```
...and independent from the content of the PR, I think exporting data interfaces from within `@lib/types` might be helpful, if just to further differentiate type imports vs. "thing" imports.

```typescript
import type { Tavern } from '@lib/types';
```