### PR TITLE
Fix highlighting of new buildings

### DIFF
--- a/src/Start/CreateBuilding.twee
+++ b/src/Start/CreateBuilding.twee
@@ -6,7 +6,7 @@
   <<run console.log(_latestBuilding)>>
   <<replace "#buildings">><<include "RoadsList">>
   <</replace>>
-  <<run document.getElementById(_latestBuilding.name).className = 'highlight'>>
+  <<run document.querySelector("[class='tip " + _latestBuilding.key + "']").className = 'highlight'>>
   /* State.create() is an undocumented feature that adds a Moment (the current state) to the story's History. 
   Notably, it may not play nicely with the Back and Forward navigation. 
   This has been implemented to ensure that the creation of new buildings is saved and no data is lost. */


### PR DESCRIPTION
## What does this do?

Fixes an error when trying to highlight new buildings. Apparently the tippy refactor broke it.

## How was this tested? Did you test the changes in the compiled `.html` file?

Tested in the HTML.

## Is there a [GitHub Issue](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aopen+is%3Aissue) that this is resolving?

I don't think so?

