### PR TITLE
Fix typo

### DIFF
--- a/lib/town/townData.ts
+++ b/lib/town/townData.ts
@@ -840,7 +840,7 @@ export const townData: TownData = {
     'absolute monarchy': {
       politicalIdeology: ['autocracy', 'autocracy', 'autocracy', 'meritocracy', 'democracy', 'kleptocracy', 'magocracy', 'militocracy', 'oligarchy', 'sophocracy', 'theocracy', 'technocracy'],
       autocracy: {
-        politicalSourceDescription: "<<print $town.leader.title.toUpperFirst()>> <<profile $npcs[$town.leader.key]>> is the supreme ruler, and all laws and affairs are governed by the crowns' will.",
+        politicalSourceDescription: "<<print $town.leader.title.toUpperFirst()>> <<profile $npcs[$town.leader.key]>> is the supreme ruler, and all laws and affairs are governed by the crown's will.",
         description: 'The crown holds both supreme executive and judicial powers.'
       },
       default: {


### PR DESCRIPTION
## What does this do?

Fixes a typo. Crowns' is plural possessive, while it's meant to be singular possessive.

## How was this tested? Did you test the changes in the compiled `.html` file?

No, it's a single character change.

## Is there a [GitHub Issue](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aopen+is%3Aissue) that this is resolving?

No.
