### PR TITLE
Fix last name comparison

### DIFF
--- a/lib/npc-generation/raceTraits.ts
+++ b/lib/npc-generation/raceTraits.ts
@@ -1245,7 +1245,7 @@ export const raceTraits: Record<RaceName, RaceTrait> = {
 
       },
       woman: {
-        firstName: ['Achuak','Aryte','Baeshra','Darastrix','Garurt','Irhtos','Jhank','Kepesk','Kethend','Korth','Kosj','Kothar','Litrix','Mirik','Othokent','Sauriv','Throden','Thurkear','Usk','Valignat','Vargach','Verthica','Vutha','Vyth'],
+        firstName: ['Achuak', 'Aesthyr', 'Athear', 'Caesin', 'Darastrix', 'Edar', 'Irhtos', 'Isk', 'Jhank', 'Kepesk', 'Kethend', 'Kosj', 'Kothar', 'Mirik', 'Othokent', 'Throden', 'Usk', 'Ulhar', 'Vignar', 'Vorel'],
         beardProbability: 0,
         baseHeight: 65,
         baseWeight: 200,
@@ -1253,7 +1253,7 @@ export const raceTraits: Record<RaceName, RaceTrait> = {
         weightModifier: () => dice(2, 6)
       },
       man: {
-        firstName: ['Achuak','Aryte','Baeshra','Darastrix','Garurt','Irhtos','Jhank','Kepesk','Kethend','Korth','Kosj','Kothar','Litrix','Mirik','Othokent','Sauriv','Throden','Thurkear','Usk','Valignat','Vargach','Verthica','Vutha','Vyth'],
+        firstName: ['Achuak', 'Aryte', 'Arytiss', 'Baeshra', 'Darastrix', 'Garurt', 'Jhank', 'Kepesk', 'Korth', 'Kosj', 'Litrix', 'Mirik', 'Othokent', 'Sauriv', 'Thurkear', 'Usk', 'Valignat', 'Vargach', 'Verthica', 'Vutha', 'Vyth'],
         beardProbability: 0,
         baseHeight: 65,
         baseWeight: 210,
@@ -1274,8 +1274,8 @@ export const raceTraits: Record<RaceName, RaceTrait> = {
     beard: [''],
     abilities: {
       'Cunning Artisan': "As part of a short rest, you can harvest bone and hide from a slain beast, construct, dragon, monstrosity, or plant creature of size Small or larger to create one of the following items: a shield, a club, a javelin, or 1d4 darts or blowgun needles. To use this trait, you need a blade, such as a dagger, or appropriate artisan's tools, such as leatherworker's tools.",
-      'Hold Breath': "You can hold your breath for up to 15 minutes at a time.",
-      "Hunter's Lore": "You gain proficiency with two of the following skills of your choice: Animal Handling, Nature, Perception, Stealth, and Survival.",
+      'Hold Breath': 'You can hold your breath for up to 15 minutes at a time.',
+      "Hunter's Lore": 'You gain proficiency with two of the following skills of your choice: Animal Handling, Nature, Perception, Stealth, and Survival.',
       'Natural Armor': "You have tough, scaly skin. When you aren't wearing armor, your AC is 13 + your Dexterity modifier. You can use your natural armor to determine your AC if the armor you wear would leave you with a lower AC. A shield's benefits apply as normal while you use your natural armor.",
       'Hungry Jaws': "In battle, you can throw yourself into a vicious feeding frenzy. As a bonus action, you can make a special attack with your bite. If the attack hits, it deals its normal damage, and you gain temporary hit points (minimum of 1) equal to your Constitution modifier, and you can't use this trait again until you finish a short or long rest."
     }

--- a/src/NPCGeneration/createNPC.ts
+++ b/src/NPCGeneration/createNPC.ts
@@ -58,7 +58,7 @@ export const createNPC = (town: Town, base = defaultBase): NPC => {
 
   const firstName = base.firstName || getFirstName(race, base.gender)
   let lastName = base.lastName || getLastName(race)
-  if (lastName === firstName) {
+  if (lastName === '') {
     lastName = firstName
   }
   console.groupCollapsed(`${firstName} ${lastName}`)


### PR DESCRIPTION
## What does this do?

Fix the comparison to see if the last name is empty 

## How was this tested? Did you test the changes in the compiled `.html` file?

Tested locally

## Is there a [GitHub Issue](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aopen+is%3Aissue) that this is resolving?

