### PR TITLE
Fixing type errors in build

### DIFF
--- a/lib/src/findInContainer.ts
+++ b/lib/src/findInContainer.ts
@@ -25,7 +25,7 @@ export function findInContainer<T> (container: Record<string, T>) {
 
     for (const object of keys(container)) {
       const nested = container[object]
-      const values = nested[key] as Values<V>
+      const values = nested[key] as unknown as Values<V>
 
       if (values?.includes(value)) {
         console.log(`Found ${value} in ${object}`)

--- a/src/Settings/Tippy/tooltips.ts
+++ b/src/Settings/Tippy/tooltips.ts
@@ -105,17 +105,23 @@ export const politicsTooltip = (id: string, type: SocioPoliticalIdeologies, town
 
 export const createPercentageTooltip = (source: HTMLElement, target: string, content: string) => {
   const tip = $(`<span class='tip dotted'>${content}</span>`)
-  tippy(tip.get(0), {
-    content: source,
-    interactive: true,
-    allowHTML: true
-  })
+  const element = tip.get(0)
+  if (element) {
+    tippy(element, {
+      content: source,
+      interactive: true,
+      allowHTML: true
+    })
+  }
   // this isn't working properly with multiple elements on the same page with the same target
   // const htmlTarget = Array.from(document.getElementsByClassName(target))
   const htmlTarget = $(`.${target}`)
 
   for (const element of htmlTarget) {
-    $(tip.get(0)).appendTo(element)
+    const tipGet = tip.get(0)
+    if (tipGet) {
+      $(tipGet).appendTo(element)
+    }
   }
 }
 
@@ -126,11 +132,13 @@ export function createRaceHTML (percentages: Record<RaceName, number>, target: s
   const array = lib.sortArray(percentages).reverse()
   const list = lib.formatPercentile(array as [string, number][])
   const html = lib.formatArrayAsList(list)
+  if (!html) return
   createPercentageTooltip(html, target, content || lib.getPredominantRace(percentages).amountDescriptive)
 }
 
 export function createReligionHTML (percentages: Record<string, number>, target: string, content?: string) {
   const html = lib.formatAsList(percentages)
+  if (!html) return
   createPercentageTooltip(html, target, content || lib.getPredominantReligion(State.variables.town, percentages).amountDescriptive)
   const button = $('<button/>', {
     text: 'Edit',

--- a/src/Tools/profile.ts
+++ b/src/Tools/profile.ts
@@ -55,7 +55,10 @@ Macro.add('profile', {
       })
     /* do any other title addition and stuff here */
     setup.makeTippyTitle($(tip)[0], obj)
-    tippy(tip.get(0), tippyOpts)
-    $(this.output).append(tip)
+    const htmlElement = tip.get(0)
+    if (htmlElement) {
+      tippy(htmlElement, tippyOpts)
+      $(this.output).append(tip)
+    }
   }
 })


### PR DESCRIPTION
## What does this do?

Fixes type errors in the build. Stolen from `refactoring-js` branch! Thanks!

## How was this tested? Did you test the changes in the compiled `.html` file?

Saw some tooltips

## Is there a [GitHub Issue](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aopen+is%3Aissue) that this is resolving?

Nope - builds are failing though. This should fix the failures because of type checking not working.
