### PR TITLE
Fix general generalStoreRenders test

### DIFF
--- a/lib/general-store/_common.ts
+++ b/lib/general-store/_common.ts
@@ -1,18 +1,16 @@
 import { BuildingRollsDefault } from '../buildings/_common'
 import { NPC } from '../npc-generation/_common'
 
+export interface GeneralStoreRolls extends BuildingRollsDefault {
+  activity: number
+  warmth: number
+}
+
 export interface GeneralStore {
   name: string
   associatedNPC: NPC
   assistant?: NPC
-  roll: BuildingRollsDefault & {
-    activity: number
-    expertise: number
-    reputation: number
-    sin: number
-    warmth: number
-    cleanliness: number
-  }
+  roll: GeneralStoreRolls
   size: string
   warmth: string
   cleanliness: string

--- a/lib/general-store/generalStoreRenders.test.ts
+++ b/lib/general-store/generalStoreRenders.test.ts
@@ -1,6 +1,5 @@
 import { generalStoreRenders } from './generalStoreRenders'
 import { setRandom } from '../src/random'
-import { GeneralStore } from './_common'
 
 // Set random to be deterministic
 setRandom((min: number, max: number) => (min + max) / 2)
@@ -37,7 +36,7 @@ describe('generalStoreRenders', () => {
       warmth: 'uncomfortably warm'
     }
 
-    generalStoreRenders(originalObject as GeneralStore)
+    generalStoreRenders(originalObject)
     expect(originalObject).toEqual(expectedResult)
   })
 })

--- a/lib/general-store/generalStoreRenders.test.ts
+++ b/lib/general-store/generalStoreRenders.test.ts
@@ -33,7 +33,7 @@ describe('generalStoreRenders', () => {
       activity: 'reasonably busy',
       cleanliness: 'reasonably tidy',
       expertise: 'finely-crafted',
-      size: 'slightly cramped',
+      size: 'medium',
       warmth: 'uncomfortably warm'
     }
 

--- a/lib/general-store/generalStoreRenders.ts
+++ b/lib/general-store/generalStoreRenders.ts
@@ -2,9 +2,15 @@ import { constrainRecord } from '../src/constrainRecord'
 import { getRolledFromTable, ThresholdTable } from '../src/rollFromTable'
 import { random } from '../src/random'
 import { keys, last } from '../src/utils'
-import { GeneralStore } from './_common'
+import { GeneralStoreRolls } from './_common'
 
-export function generalStoreRenders (generalStore: GeneralStore) {
+type Attributes = keyof typeof attributes
+
+interface Renderable extends Record<Attributes, string> {
+  roll: Pick<GeneralStoreRolls, Attributes>
+}
+
+export function generalStoreRenders (generalStore: Renderable) {
   // set warmth roll
   generalStore.roll.warmth = random(1, 100) + getWarmthRollModfier(generalStore.roll.size)
 


### PR DESCRIPTION
Since the `size` calculation was moved to be a threshold table, the weight changed by 1 since it does a `>=` instead of a `>`-operation. So this changes the expected test result to reflect that.

This also updates the types so that `generalStoreRenders` accepts specifically the object shape it needs, which means we don't need to pass an entire `GeneralStore` object to use it.