### PR TITLE
Remove tax getters from town object

### DIFF
--- a/lib/npc-generation/npcFinances.ts
+++ b/lib/npc-generation/npcFinances.ts
@@ -1,11 +1,9 @@
-import { logger } from '../logger'
 import { NPC } from './_common'
 import { calcPercentage } from '../src/calcPercentage'
 import { Town } from '../town/_common'
+import { getTaxRate } from '../town/getTaxRate'
 import { findProfession } from '../src/findProfession'
 import { LifestyleStandard, lifestyleStandards } from './lifestyleStandards'
-import { socialClass } from './socialClass'
-import { keys } from '../src/utils'
 
 /** `town.roll.wealth` increases or decreases npc.professionLuck by up to 10%, reflecting the strength of the economy. The expected range is between -25 and 25. */
 export function wageVariation (town: Town, npc: NPC): number {
@@ -21,7 +19,7 @@ export function npcGrossIncome (town: Town, npc: NPC): number {
 
 export function npcNetIncome (town: Town, npc: NPC): number {
   // logger.info(`Returning ${npc.name}'s net income...`)
-  return Math.round(calcPercentage(npcGrossIncome(town, npc), -npcTaxRate(town, npc)))
+  return Math.round(calcPercentage(npcGrossIncome(town, npc), -npcTaxRate(town)))
 }
 
 export function npcLifestyleStandard (town: Town, npc: NPC): LifestyleStandard {
@@ -50,18 +48,6 @@ export function npcProfit (town: Town, npc: NPC): number {
   return Math.round(npcNetIncome(town, npc) - npcTotalLifestyleExpenses(town, npc))
 }
 
-export function npcTaxRate (town: Town, npc: NPC): number {
-  let totalTax = 0
-
-  for (const tax of keys(town.taxes)) {
-    if (tax === 'land') {
-      totalTax += town.taxes[tax] * (socialClass[npc.socialClass].landRate || 1)
-    } else if (typeof town.taxes[tax] === 'number') {
-      totalTax += town.taxes[tax]
-    } else {
-      logger.error(`non-integer tax! ${town.taxes[tax]}`)
-    }
-  }
-
-  return Math.round(totalTax * 100) / 100
+export function npcTaxRate (town: Town): number {
+  return getTaxRate(town)
 }

--- a/lib/town/_common.ts
+++ b/lib/town/_common.ts
@@ -69,9 +69,6 @@ export interface Town extends TownBasics {
   politicalSourceDescription(town: Town): string
   localImage: string
   taxes: {
-    welfare: number
-    military: number
-    economics: number
     base: number
     land: number
     tithe: number

--- a/lib/town/getTaxRate.ts
+++ b/lib/town/getTaxRate.ts
@@ -11,5 +11,14 @@ export function getTaxRate (town: Town) {
     }
     logger.error('Non-integer tax!', town.taxes[tax])
   }
+
+  totalTax += calculateTax(2, town.roll.welfare)
+  totalTax += calculateTax(2, town.roll.military)
+  totalTax += calculateTax(3, town.roll.economics)
+
   return Math.round(totalTax * 100) / 100
+}
+
+function calculateTax (nominalTarget: number, economics: number) {
+  return nominalTarget + (-1 / (economics + 0.1)) + (1 / (10 - economics))
 }

--- a/src/NPCGeneration/NPCProfile/Components/NPCIncomeTable.twee
+++ b/src/NPCGeneration/NPCProfile/Components/NPCIncomeTable.twee
@@ -8,7 +8,7 @@
         <th>Amount</th>
     </tr>
     <tr><td>Gross Income</td><td><<print setup.money(lib.npcGrossIncome($town, $currentNPC))>></td></tr>
-    <tr><td><i>Tax</i></td><td><i><<print setup.money(lib.npcTaxRate($town, $currentNPC))>></i></td></tr>
+    <tr><td><i>Tax</i></td><td><i><<print setup.money(lib.npcTaxRate($town))>></i></td></tr>
     <tr><td>Net Income</td><td><<print setup.money(lib.npcNetIncome($town, $currentNPC))>></td></tr>
     <tr><td>Total Lifestyle Expenses (<<print lib.createTippyFull($currentNPC.firstName + " " + lib.npcLifestyleStandard($town, $currentNPC).lifestyleDescription, lib.npcLifestyleStandard($town, $currentNPC).lifestyleStandard)>>)</td><td><<print setup.money(lib.npcTotalLifestyleExpenses($town, $currentNPC))>></td></tr>
     <tr><td>Profit</td><td><<print setup.money(lib.npcProfit($town, $currentNPC))>></td></tr>

--- a/src/Town/js/createTown.ts
+++ b/src/Town/js/createTown.ts
@@ -185,31 +185,6 @@ export const createTown = (base: TownBasics | Town) => {
   town.materialProbability = lib.structureMaterialData.types
   if (State.metadata.has('pantheon')) town.religion._customPantheon = State.metadata.get('pantheon')
 
-  lib.logger.info('Defining taxes')
-  Object.defineProperty(town.taxes, 'welfare', {
-    get () {
-      lib.logger.info(this)
-      // TODO fix the getter's workaround.
-      return calculateTax(2, State.variables.town.roll.welfare)
-    }
-  })
-
-  Object.defineProperty(town.taxes, 'military', {
-    get () {
-      lib.logger.info(this)
-      // TODO fix the getter's workaround.
-      return calculateTax(2, State.variables.town.roll.military)
-    }
-  })
-
-  Object.defineProperty(town.taxes, 'economics', {
-    get () {
-      lib.logger.info(this)
-      // TODO fix the getter's workaround.
-      return calculateTax(3, State.variables.town.roll.economics)
-    }
-  })
-
   if (town.generated === 'biome') {
     lib.createTownReligion(town as unknown as Town)
     assignSizeModifiers(town)
@@ -251,10 +226,6 @@ export const createTown = (base: TownBasics | Town) => {
   lib.logger.info(`${town.name} has loaded.`)
   lib.logger.info(town)
   return town as unknown as Town
-}
-
-function calculateTax (nominalTarget: number, economics: number) {
-  return nominalTarget + (-1 / (economics + 0.1)) + (1 / (10 - economics))
 }
 
 function assignSizeModifiers (town: TownBasics) {


### PR DESCRIPTION
Removes a few getters from the town object by calculating taxes based on rolls on the fly.
Also cleans up the `npcTaxRate` function. 