### PR TITLE
fix broken createTownName reference

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -180,7 +180,6 @@ Object.assign(setup, {
   leaderFaction,
   plothooks,
   createTownBiome,
-  createTownName,
   createTown,
   findViaKey,
   findIfExistsViaKey,


### PR DESCRIPTION
Fixes a crash from trying to reference a function which is no longer available.