### PR TITLE
Cleanup partial tippys

### DIFF
--- a/lib/src/tippy.ts
+++ b/lib/src/tippy.ts
@@ -1,31 +1,11 @@
 import { Construct, ConstructUtils } from '../constructs/_common'
-
-/**
- * To be used when you want to wrap a tippy around
- * something i.e. you know what you're doing
- *
- * **Note the lack of a closing span.**
- */
-export const createTippy = (readout: string) => {
-  const id = lib.getUUID()
-  return `<span class="tip" id="${id}" role="tooltip" tabindex="0" data-tippy-content=${JSON.stringify(readout)}><<run tippy(document.getElementById('${id}'))>>`
-}
-
-/**
- * Assumes that the first argument was created
- * using the createTippy function.
- *
- * **Note the two closing spans to accommodate this.**
- */
-export const createTippyWord = (tippy: string, word: string) => {
-  return `${tippy}<span class="dotted">${word}</span></span>`
-}
+import { getUUID } from './utils'
 
 /**
  * The function that should be used most of the time.
  */
 export const createTippyFull = (readout: string, word: string) => {
-  const id = lib.getUUID()
+  const id = getUUID()
   return `<span class="tip dotted" data-id="${id}" id="${id}" role="tooltip" tabindex="0" data-tippy-content=${JSON.stringify(readout)}>${word}<<done>><<run tippy(document.getElementById('${id}'))>><</done>></span>`
 }
 
@@ -37,6 +17,8 @@ export function createAutoTippy<C extends Construct> (utils: ConstructUtils<C>, 
 }
 
 export function addTippyAccessibility () {
-  $('.tip').attr('role', 'tooltip')
-  $('.tip').attr('tabindex', '0')
+  document.querySelectorAll('.tip').forEach(tip => {
+    tip.setAttribute('role', 'tooltip')
+    tip.setAttribute('tabindex', '0')
+  })
 }

--- a/lib/src/treasureMap.ts
+++ b/lib/src/treasureMap.ts
@@ -1,6 +1,6 @@
 import { random } from './random'
 import { assign } from './utils'
-import { createTippy, createTippyWord } from './tippy'
+import { createTippyFull } from './tippy'
 
 interface TreasureMap {
   one: string
@@ -11,7 +11,6 @@ interface TreasureMap {
   six: string
   seven: string
   readout: string
-  tippy: string
   tippyWord: string
 }
 
@@ -33,11 +32,7 @@ export const treasureMap = {
     })
 
     assign(map, {
-      tippy: createTippy(map.readout)
-    })
-
-    assign(map, {
-      tippyWord: createTippyWord(map.tippy, 'map')
+      tippyWord: createTippyFull(map.readout, 'map')
     })
 
     return map

--- a/src/World/encounters.ts
+++ b/src/World/encounters.ts
@@ -1012,9 +1012,7 @@ export const encounters: Encounter[] = [
         canBeCustom: true
       })
       const map = lib.treasureMap.create()
-      return `a ${profile(npc, 'treasure-hunter')} with a ${
-          map.tippyWord
-        }`
+      return `a ${profile(npc, 'treasure-hunter')} with a ${map.tippyWord}`
     }
   },
   {

--- a/src/World/miscData.js
+++ b/src/World/miscData.js
@@ -17,8 +17,7 @@ setup.initMisc = () => {
         }
         caravan.master = setup.createNPC(town, setup.misc.caravan.masterType[caravan.masterType])
         caravan.readout = `The caravan is ${caravan.type}, with ${caravan.animals} as the pack animals. They are transporting ${caravan.transporting}, and the general mood seems to be ${caravan.mood} The master is ${setup.profile(caravan.master, JSON.stringify(caravan.masterType))}, who is looking for ${caravan.masterLooking}. ${caravan.master.heshe.toUpperFirst()} is taking special care to avoid ${caravan.masterAvoid} and is carrying ${caravan.masterCarry} with ${caravan.master.himher}.`
-        caravan.tippy = lib.createTippy(caravan.readout)
-        caravan.tippyWord = lib.createTippyWord(caravan.tippy, 'caravan')
+        caravan.tippyWord = lib.createTippyFull(caravan.readout, 'caravan')
         return caravan
       },
       caravanType: ['a wagon train', 'a long wagon train', 'a small train of pack animals', 'a long train of pack animals', 'a train of pack animals with livestock', 'a line of people on foot with a few animals'],
@@ -98,8 +97,7 @@ setup.initMisc = () => {
             ...base
           }
           shrine.readout = `You come across a shrine dedicated to ${shrine.god}. The shrine is ${shrine.material} ${shrine.senses}`
-          shrine.tippy = lib.createTippy(shrine.readout)
-          shrine.tippyWord = lib.createTippyWord(shrine.tippy, 'shrine')
+          shrine.tippyWord = lib.createTippyFull(shrine.readout, 'shrine')
           return shrine
         },
         // the shrine is _______.


### PR DESCRIPTION
Removes the `createTippy` & `createTippyWord` utils in favour of always creating the full tippy.