### PR TITLE
Fixes for issue #630, smithy and guardhouse not created on specific road

### DIFF
--- a/src/Blacksmith/js/createSmithy.ts
+++ b/src/Blacksmith/js/createSmithy.ts
@@ -6,9 +6,11 @@ interface Options {
 }
 
 // uses setup.createNPC, setup.createSmithyName
-export const createSmithy = (town: Town, opts: Options = {}) => {
-  const smithy = (opts.newBuilding || lib.createBuilding)(town, 'smithy') as Smithy
+export const createSmithy = (town: Town, opts: Partial<Options> = {}) => {
   lib.logger.openGroup('Smithy loading...')
+
+  const createBuilding = opts.newBuilding || lib.createBuilding
+  const smithy = createBuilding(town, 'smithy', opts as Partial<Building>)
 
   smithy.associatedNPC = setup.createNPC(town, Object.assign({}, lib.smithyData.blacksmith, opts.npc))
   smithy.associatedNPC.owner = lib.random(lib.smithyData.owner)

--- a/src/MiniEstablishments/Guardhouse/createGuardhouse.ts
+++ b/src/MiniEstablishments/Guardhouse/createGuardhouse.ts
@@ -11,7 +11,7 @@ export interface Guardhouse extends Building {
 }
 
 export const createGuardhouse = (town: Town, opts: Options) => {
-  const guardhouse = (opts.newBuilding || lib.createBuilding)(town, 'guardhouse')
+  const guardhouse = (opts.newBuilding || lib.createBuilding)(town, 'guardhouse', opts)
 
   lib.assign(guardhouse, {
     initPassage: 'GuardhouseOutput',


### PR DESCRIPTION
## What does this do?

Modifies smithy and guardhouse creation code to resolve issue #630 where the respective buildings aren't added to the correct road when being created from a road page.

## How was this tested? Did you test the changes in the compiled `.html` file?

Fix was tested and verified in compiled html. 

## Is there a [GitHub Issue](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aopen+is%3Aissue) that this is resolving?

#630 