### PR TITLE
Added CreateBuilding button to Detailed Description screen #750

### DIFF
--- a/src/Start/CreateBuilding.twee
+++ b/src/Start/CreateBuilding.twee
@@ -8,11 +8,14 @@
   <<run lib.logger.info('Creating a new ' + $newBuilding)>>
   <<set _latestBuilding to setup.createNewBuilding($town, $newBuilding)>>
   <<run lib.logger.info(_latestBuilding)>>
-  <<replace "#buildings">><<include "RoadsList">>
-  <</replace>>
+  <<if document.getElementById("buildings") isnot null>>
+    <<replace "#buildings">><<include "RoadsList">>
+    <</replace>>
+  <</if>>
   <<run $('.' + _latestBuilding.key).parent().addClass('highlight')>>
   /* State.create() is an undocumented feature that adds a Moment (the current state) to the story's History. 
   Notably, it may not play nicely with the Back and Forward navigation. 
   This has been implemented to ensure that the creation of new buildings is saved and no data is lost. */
   <<run State.create(passage())>>
+  <<update>>
 <</button>></span>

--- a/src/Town/components/TownListBuildings.twee
+++ b/src/Town/components/TownListBuildings.twee
@@ -1,4 +1,5 @@
 :: TownListBuildings [nobr]
+<<include "CreateBuilding">>
 <<liveblock>>
 <table>
   <tr>


### PR DESCRIPTION
## What does this do?

Adds the CreateBuilding button as found on the start page to the 'Detailed Description'  screen.

## How was this tested? Did you test the changes in the compiled `.html` file?

Built and manually tested behaviour on start screen and details screen.

## Is there a [GitHub Issue](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aopen+is%3Aissue) that this is resolving?
#750 

