### PR TITLE
Added more street name combinations based on lower Manhattan

### DIFF
--- a/lib/alchemist/alchemistRollData.ts
+++ b/lib/alchemist/alchemistRollData.ts
@@ -1,7 +1,6 @@
 import { constrainRecord } from '../src/constrainRecord'
 import { ThresholdTable } from '../src/rollFromTable'
 
-
 interface RollData {
   description: string
   preceding: string

--- a/lib/town/townData.ts
+++ b/lib/town/townData.ts
@@ -134,8 +134,8 @@ export const townData: TownData = {
   },
   // Prefixes and Suffixes for the road names of the town
   roads: {
-    name: ['Castle', 'Keep', 'Kings', 'Queens', 'Prince', 'Princess', 'Lords', 'Ladies', 'Noble', 'Duke', 'Duchess', 'Rogue', 'Priest', 'Abbott', 'Pope', 'Spring', 'Winter', 'Summer', 'Autumn', 'Butcher', 'Tailor', 'Smith', 'Potter', 'Baker', 'Farrier', 'Old', 'New', 'Common', 'Main', 'High', 'Low', 'Butcher', 'Tailor', 'Smith', 'Potter', 'Baker', 'Farrier', 'Old', 'New', 'Common', 'Main', 'High', 'Low', 'North', 'South', 'West', 'East'],
-    type: ['Street', 'Street', 'Street', 'Street', 'Lane', 'Lane', 'Lane', 'Road', 'Road', 'Road', 'Road', 'Square', 'Square', 'Market', 'Way', 'Crescent', 'Close', 'Wynd', 'Row', 'Avenue', 'Alley', 'Drive', 'Boulevard', 'Plaza']
+    name: ['Castle', 'Keep', 'Kings', 'Queens', 'Prince', 'Princess', 'Lords', 'Ladies', 'Noble', 'Duke', 'Duchess', 'Rogue', 'Priest', 'Abbott', 'Pope', 'Saint', 'Spring', 'Winter', 'Summer', 'Autumn', 'Butcher', 'Tailor', 'Smith', 'Potter', 'Baker', 'Farrier', 'Old', 'New', 'Common', 'Main', 'High', 'Low', 'Butcher', 'Tailor', 'Smith', 'Potter', 'Baker', 'Farrier', 'Church', 'Bank', 'Old', 'New', 'Common', 'Main', 'High', 'Low', 'North', 'South', 'West', 'East', 'First', 'Water', 'Brook', 'Lake', 'Canal', 'River', 'Beach', 'Pearl', 'Broad', 'Grand', 'Cherry', 'Willow', 'Mulberry', 'Grove', 'Bridge', 'Hill', 'Ridge', 'Wall', 'Front', 'Green'],
+    type: ['Street', 'Street', 'Street', 'Street', 'Lane', 'Lane', 'Lane', 'Road', 'Road', 'Road', 'Road', 'Square', 'Square', 'Market', 'Way', 'Crescent', 'Close', 'Wynd', 'Row', 'Avenue', 'Alley', 'Drive', 'Boulevard', 'Plaza', 'Circle']
   },
   defaults: {
     type: {


### PR DESCRIPTION
## What does this do?

Includes additional road names and one road type

## How was this tested? Did you test the changes in the compiled `.html` file?

Ensured application could build. Lint and tests pass

## Is there a [GitHub Issue](https://github.com/ryceg/Eigengrau-s-Essential-Establishment-Generator/issues?q=is%3Aopen+is%3Aissue) that this is resolving?

No